### PR TITLE
Put method support

### DIFF
--- a/core/api.cfc
+++ b/core/api.cfc
@@ -205,7 +205,11 @@
 	<cffunction name="parseRequest" access="private" output="false" returnType="struct">
 		<cfset var requestObj = {} />
 		<cfset var tmp = 0 />
-
+	
+		<!--- Check for method tunnelling by clients unable to send PUT/DELETE requests (e.g. Flash Player);
+					Actual desired method will be contained in a special header --->
+ 		<cfset var httpMethodOverride = GetPageContext().getRequest().getHeader("X-HTTP-Method-Override") />
+ 
 		<!--- attempt to find the cfc for the requested uri --->
 		<cfset requestObj.matchingRegex = matchURI(getPath()) />
 
@@ -219,6 +223,12 @@
 
 		<!--- which verb is requested? --->
 		<cfset requestObj.verb = cgi.request_method />
+		
+		<!--- Should we override the actual method based on method tunnelling? --->
+    <cfif isDefined("httpMethodOverride")>
+        <cfset requestObj.verb = httpMethodOverride />
+    </cfif>
+
 		<cfif structKeyExists(application._taffy.endpoints[requestObj.matchingRegex].methods, requestObj.verb)>
 			<cfset requestObj.method = application._taffy.endpoints[requestObj.matchingRegex].methods[requestObj.verb] />
 		<cfelse>


### PR DESCRIPTION
Here are two fixes to make PUT support a little nicer.

The first allows PUT operations where the body is a single object (e.g. JSON, XML) with a specified Content Type other than typical Form fields (application/x-www-form-urlencoded). This helps a bit for @https://github.com/atuttle/Taffy/issues/#issue/26 as long as you're only uploading one file. Handling multipart bodies (multiple files, or file plus form fields) remains unresolved.

The second allows broken clients (Flash, Silverlight) who are unable to send regular PUT/DELETE requests to tunnel these requests as POSTs with a special header.
