### PR TITLE
Bug json posts

### DIFF
--- a/core/api.cfc
+++ b/core/api.cfc
@@ -316,7 +316,7 @@
 			<cfelse>
 				<cfset requestObj.queryString = "" />
 			</cfif>
-		<cfelseif ucase(requestObj.verb) eq "PUT" and (requestObj.contentType eq "application/json" or requestObj.contentType eq "text/json")>
+		<cfelseif (ucase(requestObj.verb) eq "PUT" or ucase(requestObj.verb) eq "POST") and (requestObj.contentType eq "application/json" or requestObj.contentType eq "text/json")>
 			<cfset requestObj.queryString = getPutParameters() />
 		<cfelse>
 			<cfset requestObj.queryString = cgi.query_string />


### PR DESCRIPTION
Updated API parseRequest method to read request body for POST requests as well as PULL requests for text/JSON & application/json content-type.

This allows JSON requests to be parsed and variables to be made available to resource for POST requests as well as PULL requests.
