### PR TITLE
1.1 rc

### DIFF
--- a/core/api.cfc
+++ b/core/api.cfc
@@ -494,6 +494,9 @@
 	<cffunction name="guessResourcesPath" access="private" output="false" returntype="string" hint="used to try and figure out the absolute path of the /resources folder even though this file may not be in the web root">
 		<cfset local.indexcfmpath = cgi.script_name />
 		<cfset local.resourcesPath = listDeleteAt(local.indexcfmpath, listLen(local.indexcfmpath, "/"), "/") & "/resources" />
+                <cfif GetContextRoot() NEQ "">
+                        <cfset local.resourcesPath = ReReplace(local.resourcesPath,"^#GetContextRoot()#","")>
+                </cfif>
 		<cfreturn local.resourcesPath />
 	</cffunction>
 


### PR DESCRIPTION
When trying to get the path to the resource directory, strip out the
context root.
