### PR TITLE
support for trailing slash

### DIFF
--- a/core/api.cfc
+++ b/core/api.cfc
@@ -615,9 +615,14 @@
 		</cfif>
 
 		<!--- require the uri to terminate after specified content --->
-		<cfset local.uriRegex = local.uriRegex
-							  & "((?:\.)[^\.\?]+)?"	<!--- anything other than these characters will be considered a mime-type request: / \ ? . --->
-							  & "$" />			<!--- terminate the uri (query string not included in cgi.path_info, does not need to be accounted for here) --->
+		<cfset local.uriRegex = local.uriRegex & "((?:\.)[^\.\?]+)?" />			<!--- anything other than these characters will be considered a mime-type request: / \ ? . --->
+		
+		<!--- older taffy used to support trailing slash in the URI,i.e. /someResource/, this is to maintain compatibility --->
+		<cfif right(arguments.uri,1) EQ "/">
+			<cfset local.uriRegex = local.uriRegex & "/" />			
+		</cfif>
+		
+		<cfset local.uriRegex = local.uriRegex & "$" /> <!--- terminate the uri (query string not included in cgi.path_info, does not need to be accounted for here) --->
 
 		<cfset local.returnData.uriRegex = local.uriRegex />
 


### PR DESCRIPTION
This is to add support/backward-compatibility for URI's ending in slash, i.e. /someuri/. 
