### PR TITLE
changed function name to onApplicationStart and added

### DIFF
--- a/examples/api_coldspring/Application.cfc
+++ b/examples/api_coldspring/Application.cfc
@@ -10,12 +10,14 @@
 		variables.framework.representationClass = "taffy.core.nativeJsonRepresentation";
 
 		//do your onApplicationStart stuff here
-		function applicationStartEvent(){
+		function onApplicationStart(){
 			application.beanFactory = createObject("component", "coldspring.beans.DefaultXMLBeanFactory");
 			application.beanFactory.loadBeans('/taffy/examples/api_coldspring/config/coldspring.xml');
 
 			//note that we're modifying variables.framework here, after the application variable has been set
 			variables.framework.beanFactory = application.beanFactory;
+			 super.onApplicationStart();
+
 		}
 
 	</cfscript>


### PR DESCRIPTION
super.onApplicationStart() to the end to match the conventions of
CF10 and the comment in core/api.cfc

Previously the function was never called due to the incorrect (outdated)
name. Further, the external bean factory won't be initialized without
calling super.onApplicationStart()
