### PR TITLE
added simple logger that dumps the exception info and settings to the

### DIFF
--- a/bonus/logToScreen.cfc
+++ b/bonus/logToScreen.cfc
@@ -1,0 +1,25 @@
+<cfcomponent implements="taffy.bonus.ILogAdapter">
+
+	<cffunction name="init">
+		<cfargument name="config" />
+		<cfargument name="tracker" hint="unused" default="" />
+
+		<!--- copy settings into adapter instance data --->
+		<cfset structAppend( variables, arguments.config, true ) />
+
+		<cfreturn this />
+	</cffunction>
+
+	<cffunction name="saveLog">
+		<cfargument name="exception" />
+		<!---
+			TODO: This adapter does not currently support authentication-required email, supplying a specific server, etc.
+			That would be a great and relatively easy thing for you to contribute back! :)
+		--->
+		<cfcontent type="text/html" />
+		<cfdump var="#variables#">
+		<cfdump var="#arguments#">
+		<cfabort>
+	</cffunction>
+
+</cfcomponent>


### PR DESCRIPTION
screen.

The built in bonus loggers didn't really have support for simply dumping
the issue to the screen.  While developing in an environment without
one of the other options really available to me I needed to be able to
read exception info.  This is the solution to that problem.
