### PR TITLE
added logSuppression logger which does what its name implies - nothing.

### DIFF
--- a/bonus/logSuppression.cfc
+++ b/bonus/logSuppression.cfc
@@ -1,0 +1,21 @@
+<cfcomponent implements="taffy.bonus.ILogAdapter">
+
+	<cffunction name="init">
+		<cfargument name="config" />
+		<cfargument name="tracker" hint="unused" default="" />
+
+		<!--- copy settings into adapter instance data --->
+		<cfset structAppend( variables, arguments.config, true ) />
+
+		<cfreturn this />
+	</cffunction>
+
+	<cffunction name="saveLog">
+		<cfargument name="exception" />
+		<!---
+			don't do anything..
+		--->
+
+	</cffunction>
+
+</cfcomponent>

--- a/tests/tests/TestLoggers.cfc
+++ b/tests/tests/TestLoggers.cfc
@@ -1,5 +1,24 @@
 <cfcomponent extends="base">
 	<cfscript>
+		function test_suppression() {
+
+			var mockSuppressionTracker = "";
+			var suppressionAdapter = "";
+			var suppressionSettings = {};
+			var fakeError = {};
+
+			suppressionAdapter = createObject("component", "taffy.bonus.LogSuppression").init(
+				suppressionSettings
+				, mockSuppressionTracker
+			);
+
+			//fake error
+			fakeError.message = "This is a test error";
+			fakeError.detail = "Rubber Baby Buggy Bumper";
+			suppressionAdapter.saveLog(fakeError);
+
+			//nothing happens.. so it passes. mostly this just makes sure there are no syntax errors in the component.
+		}
 
 		function test_hoth(){
 			var mockHoth = mock();


### PR DESCRIPTION
Basically the logSuppression fulfills the ILogAdapter contract but the
saveLog method does nothing.  This lets the error propogate upward where
Taffy returns the error information as a sturct with an http code of 500.  Basically,
this can be used when one has no other plan for logging the errors (I know, not a great practice by any means).

The error struct contains the following fields:
TagContext
Detail
Error

Added a really lame unit test that basically just makes sure the component
compiles and the method calls don't blow up.
