### PR TITLE
Added queryToStruct helper function

### DIFF
--- a/core/resource.cfc
+++ b/core/resource.cfc
@@ -61,11 +61,12 @@
 		<cfargument name="q" type="query" required="yes" />
 		
 		<cfscript>
+			var local = {};
+			
 			if (q.recordcount > 1){
 			 throw message="Unable to convert query resultset with more than one record to a simple struct, use queryToArray() instead";
 			}
 		
-			var local = {};
 			if (structKeyExists(server, "railo")) {
 				local.Columns = listToArray(arguments.q.getColumnList(false));
 			}


### PR DESCRIPTION
Added an additional helper function to convert a query result set with a single record to a struct as opposed to an array of length one with a struct.
