### PR TITLE
fix bug in api example

### DIFF
--- a/examples/api/Application.cfc
+++ b/examples/api/Application.cfc
@@ -14,8 +14,8 @@
 			return super.onApplicationStart();
 		}
 
-		function onRequestStart(){
-			return super.onRequestStart();
+		function onRequestStart(TARGETPATH){
+			return super.onRequestStart(TARGETPATH);
 		}
 
 		// this function is called after the request has been parsed and all request details are known


### PR DESCRIPTION
Added the TARGETPATH to the onRequestStart function in the api example.
This was causing an error on CF10.
