### PR TITLE
fix for Railo w/ "complete NULL support" ON

### DIFF
--- a/core/api.cfc
+++ b/core/api.cfc
@@ -515,7 +515,7 @@
 		<cfset requestObj.verb = cgi.request_method />
 
 		<!--- Should we override the actual method based on method tunnelling? --->
-		<cfif isDefined("httpMethodOverride")>
+		<cfif isDefined("httpMethodOverride") AND not isNull(httpMethodOverride)>
 		    <cfset requestObj.verb = httpMethodOverride />
 		</cfif>
 


### PR DESCRIPTION
In Railo Server Admin, when Null Support is set to "complete support", you receive a HTTP 405 error when attempting any REST call.  The issue is the requestObj.verb is NULL due to the 'httpMethodOverride'.  Adding this additional check on the condition fixes this.
