### PR TITLE
Change to add user friendly documentation

### DIFF
--- a/core/api.cfc
+++ b/core/api.cfc
@@ -63,13 +63,17 @@
 				AND len(local.path) lte 1
 				AND listFindNoCase(cgi.script_name, "index.cfm", "/") EQ listLen(cgi.script_name, "/")>
 				<cfif NOT application._taffy.settings.disableDashboard>
-					<cfinclude template="../dashboard/dashboard.cfm" />
+					<cfif StructKeyExists( URL, "docs" )>
+						<cfinclude template="../dashboard/docs.cfm" />
+					<cfelse>
+						<cfinclude template="../dashboard/dashboard.cfm" />
+					</cfif>
 					<cfabort />
 				<cfelse>
 					<cfif len(application._taffy.settings.disabledDashboardRedirect)>
 						<cflocation url="#application._taffy.settings.disabledDashboardRedirect#" addtoken="false" />
 						<cfabort />
-					<cfelse>
+					<cfelseif application._taffy.settings.showDocsWhenDashboardDisabled IS False>
 						<cfset throwError(403, "Forbidden") />
 					</cfif>
 				</cfif>
@@ -166,11 +170,18 @@
 			AND len(cgi.path_info) lte 1
 			AND listFindNoCase(cgi.script_name, "index.cfm", "/") EQ listLen(cgi.script_name, "/")>
 			<cfif NOT application._taffy.settings.disableDashboard>
-				<cfinclude template="../dashboard/dashboard.cfm" />
+				<cfif StructKeyExists( URL, "docs" )>
+					<cfinclude template="../dashboard/docs.cfm" />
+				<cfelse>
+					<cfinclude template="../dashboard/dashboard.cfm" />
+				</cfif>
 				<cfabort />
 			<cfelse>
 				<cfif len(application._taffy.settings.disabledDashboardRedirect)>
 					<cflocation url="#application._taffy.settings.disabledDashboardRedirect#" addtoken="false" />
+					<cfabort />
+				<cfelseif application._taffy.settings.showDocsWhenDashboardDisabled>
+					<cfinclude template="../dashboard/docs.cfm" />
 					<cfabort />
 				<cfelse>
 					<cfset throwError(403, "Forbidden") />
@@ -201,7 +212,7 @@
 			<cfelse>
 				<!--- parrot back all of the request headers to allow the request to continue (can we improve on this?) --->
 				<cfset local.allowedHeaders = {} />
-				<cfloop list="Origin,Authorization, X-CSRF-Token,X-Requested-With,Content-Type,X-HTTP-Method-Override,Accept,Referrer,User-Agent" index="local.h">
+				<cfloop list="Origin,Authorization,X-CSRF-Token,X-Requested-With,Content-Type,X-HTTP-Method-Override,Accept,Referrer,User-Agent" index="local.h">
 					<cfset local.allowedHeaders[local.h] = 1 />
 				</cfloop>
 				<cfset local.requestedHeaders = _taffyRequest.headers['Access-Control-Request-Headers'] />
@@ -395,6 +406,9 @@
 		<cfset application._taffy.endpoints = structNew() />
 		<!--- default settings --->
 		<cfset local.defaultConfig = structNew() />
+		<cfset local.defaultConfig.docs = structNew() />
+		<cfset local.defaultConfig.docs.APIName = "Your API Name (variables.framework.docs.APIName)" />
+		<cfset local.defaultConfig.docs.APIVersion = "0.0.0 (variables.framework.docs.APIVersion)" />
 		<cfset local.defaultConfig.defaultMime = "" />
 		<cfset local.defaultConfig.debugKey = "debug" />
 		<cfset local.defaultConfig.reloadKey = "reload" />
@@ -405,6 +419,7 @@
 		<cfset local.defaultConfig.dashboardKey = "dashboard" />
 		<cfset local.defaultConfig.disableDashboard = false />
 		<cfset local.defaultConfig.disabledDashboardRedirect = "" />
+		<cfset local.defaultConfig.showDocsWhenDashboardDisabled = false />
 		<cfset local.defaultConfig.unhandledPaths = "/flex2gateway" />
 		<cfset local.defaultConfig.allowCrossDomain = false />
 		<cfset local.defaultConfig.useEtags = false />

--- a/dashboard/dashboard.cfm
+++ b/dashboard/dashboard.cfm
@@ -15,6 +15,7 @@
 	<div class="container">
 
 		<div class="masthead">
+			<button id="docs" class="btn btn-success" onclick="window.location.href = '<cfoutput>#CGI.SCRIPT_NAME#</cfoutput>?docs'">Documentation</button>
 			<button id="reload" class="btn btn-info">Reload API Cache</button>
 			<button data-toggle="modal" data-target="#config" class="btn btn-default">Config</button>
 			<h1>API Dashboard</h1>

--- a/dashboard/docs.cfm
+++ b/dashboard/docs.cfm
@@ -1,0 +1,124 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+	<title>Taffy Dashboard</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<style>
+		<cfinclude template="dash.css" />
+	</style>
+</head>
+<body>
+	<script>
+		window.taffy = { resources: {} };
+	</script>
+
+	<div class="container">
+		<div class="masthead">
+			<h1><cfoutput>#application._taffy.settings.docs.APIName#</cfoutput></h1>
+			<span class="ver text-muted" style="left: 0">Version <cfoutput>#application._taffy.settings.docs.APIversion#</cfoutput></span>
+		</div>
+
+		<div class="row" id="resources">
+			<h3>Resources:</h3>
+			<div class="panel-group" id="resourcesAccordion">
+				<cfoutput>
+					<cfloop from="1" to="#arrayLen(application._taffy.uriMatchOrder)#" index="local.resource">
+						<cfset local.currentResource = application._taffy.endpoints[application._taffy.uriMatchOrder[local.resource]] />
+						<div class="panel panel-default">
+							<div class="panel-heading">
+								<h4 class="panel-title">
+									<a href="###local.currentResource.beanName#" class="accordion-toggle" data-toggle="collapse" data-parent="##resourcesAccordion">
+										#local.currentResource.beanName#
+									</a>
+									<cfloop list="DELETE|warning,PATCH|warning,PUT|warning,POST|danger,GET|primary" index="local.verb">
+										<cfif structKeyExists(local.currentResource.methods, listFirst(local.verb,'|'))>
+											<span class="verb label label-success">#ucase(listFirst(local.verb,'|'))#</span>
+										</cfif>
+									</cfloop>
+									<code style="float:right; margin-top: -15px; display: inline-block;">#local.currentResource.srcUri#</code>
+								</h4>
+							</div>
+							<div id="#local.currentResource.beanName#">
+								<div class="panel-body resourceWrapper">
+									<div class="col-md-12 docs">
+										<cfset local.metadata = getMetaData(application._taffy.factory.getBean(local.currentResource.beanName)) />
+										<cfset local.docData = getHintsFromMetadata(local.metadata) />
+										<cfif structKeyExists(local.docData, 'hint')><div class="doc">#docData.hint#</div><hr/></cfif>
+										<cfset local.found = { get=false, post=false, put=false, patch=false, delete=false } />
+										<cfloop from="1" to="#arrayLen(local.docData.functions)#" index="local.f">
+											<cfset local.func = local.docData.functions[local.f] />
+											<cfset local.found[local.func.name] = true />
+											<div class="col-md-12"><strong>#local.func.name#</strong></div>
+											<cfif structKeyExists(local.func, "hint")>
+												<div class="col-md-12 doc">#local.func.hint#</div>
+											</cfif>
+											<cfloop from="1" to="#arrayLen(local.func.parameters)#" index="local.p">
+												<cfset local.param = local.func.parameters[local.p] />
+												<div class="row">
+													<div class="col-md-11 col-md-offset-1">
+															<cfif not structKeyExists(local.param, 'required') or not local.param.required>
+																optional
+															<cfelse>
+																required
+															</cfif>
+															<cfif structKeyExists(local.param, "type")>
+																#local.param.type#
+															</cfif>
+															<strong>#local.param.name#</strong>
+															<cfif structKeyExists(local.param, "default")>
+																<cfif local.param.default eq "">
+																	(default: "")
+																<cfelse>
+																	(default: #local.param.default#)
+																</cfif>
+															<cfelse>
+																<!--- no default value --->
+															</cfif>
+														<cfif structKeyExists(local.param, "hint")>
+															<br/><span class="doc">#local.param.hint#</span>
+														</cfif>
+													</div>
+												</div>
+											</cfloop>
+										</cfloop>
+									</div><!-- /col-md-6 (docs) -->
+								</div>
+							</div>
+						</div>
+					</cfloop>
+				</cfoutput>
+			</div><!-- /panel-group -->
+			<br />
+			<cfif arrayLen(application._taffy.uriMatchOrder) eq 0>
+				<div class="panel panel-warning">
+					<div class="panel-heading">Taffy is running but you haven't defined any resources yet.</div>
+					<div class="panel-body">
+						<p>
+							It looks like you don't have any resources defined. Get started by creating the folder
+							<code><cfoutput>#guessResourcesFullPath()#</cfoutput></code>, in which you should place your
+							Resource CFC's.
+						</p>
+						<p>
+							Or you could set up a bean factory, like <a href="http://www.coldspringframework.org/">ColdSpring</a>
+							or <a href="https://github.com/seancorfield/di1">DI/1</a>. Want to know more about using bean factories with Taffy?
+							<a href="https://github.com/atuttle/Taffy/wiki/So-you-want-to:-use-an-external-bean-factory-like-coldspring-to-completely-manage-resources"
+							>Check out the wiki!</a>
+						</p>
+						<p>
+							If all else fails, I recommend starting with <a href="https://github.com/atuttle/Taffy/wiki/Getting-Started">Getting Started</a>.
+						</p>
+					</div>
+				</div>
+			</cfif>
+			<div class="alert alert-info">Resources are listed in matching order. From top to bottom, the first URI to match the request is used.</div>
+		</div><!-- /#resources -->
+
+	</div><!-- /container -->
+
+	<script type="text/javascript">
+		<cfinclude template="jquery.min.js" />
+		<cfinclude template="bootstrap.min.js" />
+		<cfinclude template="dash.js" />
+	</script>
+</body>
+</html>


### PR DESCRIPTION
Added a new docs.cfm to show user friendly and printable documentation for users. The docs.cfm file will show when the dashboard is disabled, and if the user has set the showDocsWhenDashboardDisabled to True.
showDocsWhenDashboardDisabled defaults to false in order to maintain backward compatibility.

Documentation Display:
![documentation](https://cloud.githubusercontent.com/assets/44993/3858532/a847abd8-1f0e-11e4-948f-6052d911677c.png)

Added a button to the API Dashboard:
![documentationbutton-1](https://cloud.githubusercontent.com/assets/44993/3858508/8027342a-1f0e-11e4-96d3-f9408a60f355.png)

New settings:
showDocsWhenDashboardDisabled: True or False
docs.APIName: The name of the API to show in the documentation, replaces "Taffy"
docs.APIVersion: The version of the API to show in the documentation, replaces the Taffy version number
