### PR TITLE
Use client-side host for generating dashboard request URLs

### DIFF
--- a/dashboard/dashboard.cfm
+++ b/dashboard/dashboard.cfm
@@ -466,7 +466,7 @@
 			});
 		});
 		function submitRequest( verb, resource, headers, body, callback ){
-			var url = window.location.protocol + '//<cfoutput>#cgi.server_name#</cfoutput>';
+			var url = window.location.protocol + '//' +  window.location.host + ((window.location.port) ? ':' + window.location.port : '');
 			var endpointURLParam = '<cfoutput>#jsStringFormat(application._taffy.settings.endpointURLParam)#</cfoutput>';
 			var endpoint = resource.split('?')[0];
 			var args = '';


### PR DESCRIPTION
I explained my motivation for this change on [Taffy Users](https://groups.google.com/d/msg/taffy-users/kh3QeKY4F3o/bHvzWBfyA8gJ).  Basically my CGI.SERVER_NAME was not a resolvable name and so I'm swapping server-side logic for client-side.
