### PR TITLE
Exception for QoQ with blank column name

### DIFF
--- a/core/resource.cfc
+++ b/core/resource.cfc
@@ -90,10 +90,12 @@
 
 			for (local.ColumnIndex = 1; local.ColumnIndex <= local.numCols; local.ColumnIndex++){
 				local.ColumnName = local.Columns[ local.ColumnIndex ];
-				if ( structKeyExists( arguments, "cb" ) ) {
-					local.QueryStruct[ local.ColumnName ] = cb( local.ColumnName, arguments.q[ local.ColumnName ][1] );
-				} else {
-					local.QueryStruct[ local.ColumnName ] = arguments.q[ local.ColumnName ][1];
+				if( local.ColumnName NEQ "" ) {
+					if ( structKeyExists( arguments, "cb" ) ) {
+						local.QueryStruct[ local.ColumnName ] = cb( local.ColumnName, arguments.q[ local.ColumnName ][1] );
+					} else {
+						local.QueryStruct[ local.ColumnName ] = arguments.q[ local.ColumnName ][1];
+					}
 				}
 			}
 


### PR DESCRIPTION
There are instances where a column name from a QoQ could return an
empty string as a column name, causing an exception when trying to
reference that column name when converting a query to an array. This
change will ensure that we have a valid column name before attempting
to reference it.
