### PR TITLE
Dashboard regex tokens not matched

### DIFF
--- a/dashboard/dash.js
+++ b/dashboard/dash.js
@@ -199,12 +199,13 @@ function parseHeaders(h){
 	return out;
 }
 
-// http://javascript.crockford.com/remedial.html
 String.prototype.supplant = function (o) {
-    return this.replace(/{([^{}]*)}/g,
+    return this.replace(/{(.*?)(}(?=\/)|}$)/g,
         function (a, b) {
-            var r = o[b];
+        	// We need to split on the : if we're using custom token regular expressions.
+            var r = o[ b.split(':')[ 0 ] ];
             return typeof r === 'string' || typeof r === 'number' ? r : a;
         }
     );
 };
+


### PR DESCRIPTION
When using the following taffy:uri, the dashboard did not correctly replace the tokens in the sample resource URI:

```
taffy_uri="/member/{id:\d+}"
```

I adjusted the supplant prototype function to match all characters within the `{}`. I had to play some tricks with it to ensure that it could catch matches within `/`s and at the end of a string.

```
{ //Start with a curly brace for the match
(.*?) //Match as few characters until the next match
( //Start a new grouping
    }(?=\/) //Catch a curly brace immediately followed by a /
    | // OR
    }$ //A curly brace at the end of the string
) //End the group
```

Will now match all items in the following resource uri:

```
/member/{id}/county/{type}/{foo:\d+}/{foo:\d{2}}
```
