### PR TITLE
Documentation link fix

### DIFF
--- a/dashboard/dashboard.cfm
+++ b/dashboard/dashboard.cfm
@@ -516,5 +516,5 @@
 
 <cffunction name="getDocUrl">
 	<cfargument name="item" />
-	<cfreturn "http://docs.taffy.io/#application._taffy.version#/##" & item />
+	<cfreturn "http://docs.taffy.io/#listFirst(application._taffy.version,'-')#/##" & item />
 </cffunction>


### PR DESCRIPTION
The Version ID for 3.0.0-alpha links to http://docs.taffy.io/3.0.0-alpha (wrong) instead of http://docs.taffy.io/3.0.0 (correct). This change allows -alpha/-beta suffixes without ruining the embedded links.
