### PR TITLE
https://github.com/atuttle/Taffy/issues/239

### DIFF
--- a/core/api.cfc
+++ b/core/api.cfc
@@ -530,7 +530,7 @@
 			<cfset local._taffy.factory = local._taffy.externalBeanFactory />
 			<!--- since external factory is only factory, check it for taffy resources --->
 			<cfset local.beanList = getBeanListFromExternalFactory( local._taffy.externalBeanFactory ) />
-			<cfset local._taffy.endpoints = cacheBeanMetaData(local._taffy.externalBeanFactory, local.beanList) />
+			<cfset local._taffy.endpoints = cacheBeanMetaData(local._taffy.externalBeanFactory, local.beanList, local._taffy) />
  		<cfelse>
  			<cfset local.noResources = true />
 		</cfif>

--- a/core/factory.cfc
+++ b/core/factory.cfc
@@ -50,12 +50,13 @@
 		<cfargument name="resourcesPath" type="string" default="resources" />
 		<cfargument name="resourcesBasePath" type="string" default="" />
 		<cfargument name="isFullReload" type="boolean" default="false" />
+		<cfargument name="taffyRef" type="any" required="false" default="#structNew()#" />
 		<cfset var local = StructNew() />
 		<!--- cache all of the beans --->
 		<cfif isFullReload>
 			<cfset this.beans = structNew() />
-			<cfset application._taffy.status.skippedResources = arrayNew(1) /> <!--- empty out the array on factory reloads --->
-			<cfset application._taffy.beanList = "" />
+			<cfset arguments.taffyRef.status.skippedResources = arrayNew(1) /> <!--- empty out the array on factory reloads --->
+			<cfset arguments.taffyRef.beanList = "" />
 		</cfif>
 		<!--- if the folder doesn't exist, do nothing --->
 		<cfif not directoryExists(arguments.beanPath)>
@@ -78,7 +79,7 @@
 					<cfset local.err = structNew() />
 					<cfset local.err.resource = local.beanName />
 					<cfset local.err.exception = cfcatch />
-					<cfset arrayAppend(application._taffy.status.skippedResources, local.err) />
+					<cfset arrayAppend(arguments.taffyRef.status.skippedResources, local.err) />
 				</cfcatch>
 			</cftry>
 		</cfloop>

--- a/tests/resources/ConflictingURI.cfc
+++ b/tests/resources/ConflictingURI.cfc
@@ -1,0 +1,11 @@
+<cfcomponent extends="taffy.core.resource" taffy:uri="/conflict/{URI}, /conflict/{URI}" hint="I have multiple uris">
+
+	<cffunction name="get">
+		<cfargument name="uri" type="string" default="0" />
+		<cfset local.res = {} />
+		<cfset local.res.uri = arguments.uri />
+
+		<cfreturn representationOf(local.res) />
+	</cffunction>
+
+</cfcomponent>

--- a/tests/resources/EchoURIAlias.cfc
+++ b/tests/resources/EchoURIAlias.cfc
@@ -1,0 +1,21 @@
+<cfcomponent extends="taffy.core.resource" taffy:uri="/echo_alias/{id}, /echo_alias" hint="I have multiple uris">
+
+	<cffunction name="get">
+		<cfargument name="id" default="0" />
+		<cfset local.res = {} />
+		<cfset local.res.id = arguments.id />
+
+		<cfreturn representationOf(local.res) />
+	</cffunction>
+
+	<cffunction name="put">
+		<cfargument name="id" />
+		<cfreturn representationOf(arguments).withStatus(200) />
+	</cffunction>
+
+	<cffunction name="post">
+		<cfargument name="id" />
+		<cfreturn representationOf(arguments).withStatus(200) />
+	</cffunction>
+
+</cfcomponent>

--- a/tests/tests/TestConflict.cfc
+++ b/tests/tests/TestConflict.cfc
@@ -1,0 +1,26 @@
+<cfcomponent extends="base">
+
+	<cffunction name="setup">
+		<cfset local.apiRootURL	= getDirectoryFromPath(cgi.script_name) />
+		<cfset local.apiRootURL	= listDeleteAt(local.apiRootURL,listLen(local.apiRootURL,'/'),'/') />
+		<cfhttp method="GET" url="http://#CGI.SERVER_NAME#:#CGI.SERVER_PORT##local.apiRootURL#/index.cfm?#application._taffy.settings.reloadkey#=#application._taffy.settings.reloadPassword#" />
+	</cffunction>
+
+	<cfscript>
+		function beforeTests(){
+			variables.taffy = createObject("component","taffy.tests.Application");
+			makePublic(variables.taffy, "getBeanFactory");
+			variables.factory = variables.taffy.getBeanFactory();
+			variables.factory.loadBeansFromPath( expandPath('/taffy/tests/resourcesConflict'), 'taffy.tests.resourcesConflict', expandPath('/taffy/tests/resourcesConflict'), true, variables.taffy);
+
+		}
+
+		function conflicting_URIs_get_skipped() {
+			assertEquals(1, arrayLen(application._taffy.status.skippedResources), "Conflicting URIs not showing in errors");
+			var err = application._taffy.status.skippedResources[1];
+			assertEquals("taffy.resources.DuplicateUriPattern", local.err.Exception.ErrorCode);
+		}
+	</cfscript>
+
+
+</cfcomponent>

--- a/tests/tests/TestCore.cfc
+++ b/tests/tests/TestCore.cfc
@@ -559,6 +559,33 @@
 			assertTrue(isArray(local.response._body));
 			assertTrue(arrayLen(local.response._body) == 3);
 		}
+
+		function comma_delim_list_of_uris_for_alias(){
+
+			//works with /echo_alias/{ID}
+			local.result = apiCall("get", "/echo_alias/4", "");
+			// debug(local.result);
+			assertEquals(200, val(local.result.statusCode));
+			assertEquals(serializeJSON({ID=4}), local.result.fileContent);
+
+			//works with /echo_alias
+			local.result = apiCall("get", "/echo_alias", "");
+			// debug(local.result);
+			assertEquals(200, val(local.result.statusCode));
+			assertEquals(serializeJSON({ID=0}), local.result.fileContent);
+
+			//works with /echo_alias/ (trailing slash)
+			local.result = apiCall("get", "/echo_alias/", "");
+			// debug(local.result);
+			assertEquals(200, val(local.result.statusCode));
+			assertEquals(serializeJSON({ID=0}), local.result.fileContent);
+
+			//works with /echo_alias?ID=x
+			local.result = apiCall("get", "/echo_alias", "ID=2");
+			// debug(local.result);
+			assertEquals(200, val(local.result.statusCode));
+			assertEquals(serializeJSON({ID=2}), local.result.fileContent);
+		}
 	</cfscript>
 
 

--- a/tests/tests/TestFactory.cfc
+++ b/tests/tests/TestFactory.cfc
@@ -5,7 +5,7 @@
 			variables.taffy = createObject("component","taffy.tests.Application");
 			makePublic(variables.taffy, "getBeanFactory");
 			variables.factory = variables.taffy.getBeanFactory();
-			variables.factory.loadBeansFromPath( expandPath('/taffy/tests/resources'), 'taffy.tests.resources', expandPath('/taffy/tests/resources'), true );
+			variables.factory.loadBeansFromPath( expandPath('/taffy/tests/resources'), 'taffy.tests.resources', expandPath('/taffy/tests/resources'), true, variables.taffy);
 		}
 
 		function throws_on_getBean_not_exists(){
@@ -55,27 +55,27 @@
 
 		function skips_resources_with_errors(){
 			variables.factory.loadBeansFromPath( expandPath('/taffy/tests/resourcesError'), 'taffy.tests.resourcesError', expandPath('/taffy/tests/resourcesError'), true );
-			// debug(application._taffy.status);
-			assertTrue(structKeyExists(application._taffy.status, "skippedResources"));
+			// debug(variables.taffy.status);
+			assertTrue(structKeyExists(variables.taffy.status, "skippedResources"));
 		}
 
 		function lists_skipped_resources(){
-			variables.factory.loadBeansFromPath( expandPath('/taffy/tests/resourcesError'), 'taffy.tests.resourcesError', expandPath('/taffy/tests/resourcesError'), true );
-			// debug(application._taffy.status);
-			assertTrue(structKeyExists(application._taffy.status, "skippedResources"));
-			assertTrue( arrayLen(application._taffy.status.skippedResources) gt 0 );
+			variables.factory.loadBeansFromPath( expandPath('/taffy/tests/resourcesError'), 'taffy.tests.resourcesError', expandPath('/taffy/tests/resourcesError'), true, variables.taffy);
+			// debug(variables.taffy.status);
+			assertTrue(structKeyExists(variables.taffy.status, "skippedResources"));
+			assertTrue( arrayLen(variables.taffy.status.skippedResources) gt 0 );
 		}
 
 		function clears_skipped_resources_on_reload(){
-			variables.factory.loadBeansFromPath( expandPath('/taffy/tests/resourcesError'), 'taffy.tests.resourcesError', expandPath('/taffy/tests/resourcesError'), true );
-			// debug(application._taffy.status);
-			assertTrue(structKeyExists(application._taffy.status, "skippedResources"));
-			assertTrue( arrayLen(application._taffy.status.skippedResources) gt 0 );
+			variables.factory.loadBeansFromPath( expandPath('/taffy/tests/resourcesError'), 'taffy.tests.resourcesError', expandPath('/taffy/tests/resourcesError'), true, variables.taffy );
+			// debug(variables.taffy.status);
+			assertTrue(structKeyExists(variables.taffy.status, "skippedResources"));
+			assertTrue( arrayLen(variables.taffy.status.skippedResources) gt 0 );
 
-			variables.factory.loadBeansFromPath( expandPath('/taffy/tests/resources'), 'taffy.tests.resources', expandPath('/taffy/tests/resources'), true );
-			// debug(application._taffy.status);
-			assertTrue(structKeyExists(application._taffy.status, "skippedResources"));
-			assertTrue( ArrayLen(application._taffy.status.skippedResources) eq 0, "Expected skipped resources array to be empty but it wasn't" );
+			variables.factory.loadBeansFromPath( expandPath('/taffy/tests/resources'), 'taffy.tests.resources', expandPath('/taffy/tests/resources'), true, variables.taffy );
+			// debug(variables.taffy.status);
+			assertTrue(structKeyExists(variables.taffy.status, "skippedResources"));
+			assertTrue( ArrayLen(variables.taffy.status.skippedResources) eq 0, "Expected skipped resources array to be empty but it wasn't" );
 		}
 
 		function treats_CRCs_as_transients(){


### PR DESCRIPTION
Added the ability to specify a comma delimited list of URIs for taffy_uri, allowing you to specify multiple endpoint URIs to be served by the same resource .  It will not recognize commas inside of regular expression brackets {}.

Fixed an issue where status.skippedResources was being overwritten when hot-swapping.

Added tests for the new alias', as well as reconfiguring the tests to keep testing the skippedResources properly.

Added a test for conflicting URI errors.