### PR TITLE
Fixed regression from #251

### DIFF
--- a/dashboard/dashboard.cfm
+++ b/dashboard/dashboard.cfm
@@ -55,7 +55,7 @@
 							</div>
 							<div class="col-sm-6">
 								<a class="label label-default" href="<cfoutput>#getDocUrl('allowCrossDomain')#</cfoutput>">?</a>
-								#yesNoFormat(application._taffy.settings.allowCrossDomain)#
+								<cfif application._taffy.settings.allowCrossDomain EQ 'false'>No<cfelse>Yes</cfif>
 							</div>
 
 							<div class="col-sm-6">


### PR DESCRIPTION
Now that the allowCrossDomain setting can be a regular string, the framework config modal dialog on the dashboard needed to be updated to properly handle non-boolean values