### PR TITLE
resolves #253

### DIFF
--- a/core/api.cfc
+++ b/core/api.cfc
@@ -959,6 +959,21 @@
 	<cfreturn output />
 	</cffunction>
 
+	<cffunction name="throwExceptionIfURIDoesntBeginWithForwardSlash" output="false" access="private" returntype="void">
+		<cfargument name="uri" type="string" required="true">
+		<cfargument name="beanName" type="string" required="true">
+
+		<cfset var uriDoesntBeginWithForwardSlash = left(arguments.uri,1) neq "/">
+
+		<cfif uriDoesntBeginWithForwardSlash>
+			<cfthrow
+				message="URI doesn't begin with a forward slash."
+				detail="The URI (#arguments.uri#) for `#arguments.beanName#` should begin with a forward slash."
+				errorcode="taffy.resources.URIDoesntBeginWithForwardSlash"
+			/>
+		</cfif>
+	</cffunction>
+
 	<cffunction name="cacheBeanMetaData" access="private" output="false">
 		<cfargument name="factory" required="true" />
 		<cfargument name="beanList" type="string" required="true" />
@@ -998,6 +1013,9 @@
 								errorcode="taffy.resources.DuplicateUriPattern"
 							/>
 						</cfif>
+
+						<cfset throwExceptionIfURIDoesntBeginWithForwardSlash(local.uri, local.beanName)>
+
 						<cfset local.endpoints[local.metaInfo.uriRegex] = { beanName = local.cachedBeanName, tokens = local.metaInfo.tokens, methods = structNew(), srcURI = local.uri } />
 						<cfif structKeyExists(local.cfcMetadata, "functions")>
 							<cfloop array="#local.cfcMetadata.functions#" index="local.f">

--- a/dashboard/dashboard.cfm
+++ b/dashboard/dashboard.cfm
@@ -172,10 +172,16 @@
 					and arrayLen(application._taffy.status.skippedResources) gt 0>
 				<cfoutput>
 					<cfloop from="1" to="#arrayLen(application._taffy.status.skippedResources)#" index="local.i">
+
 						<cfset local.err = application._taffy.status.skippedResources[local.i] />
+						<cfset local.exceptionHasErrorCode = structKeyExists(local.err, "Exception") AND structKeyExists(local.err.Exception, "ErrorCode")>
+						<cfset local.errorCode = local.exceptionHasErrorCode and local.err.Exception.ErrorCode>
+
 						<div class="alert alert-warning">
-							<cfif structKeyExists(local.err, "Exception") AND structKeyExists(local.err.Exception, "ErrorCode") AND local.err.Exception.ErrorCode EQ "taffy.resources.DuplicateUriPattern">
+							<cfif local.errorCode EQ "taffy.resources.DuplicateUriPattern">
 								<strong class="label label-warning"><cfoutput>#local.err.resource#</cfoutput></strong> contains a conflicting URI.
+							<cfelseif local.errorcode EQ "taffy.resources.URIDoesntBeginWithForwardSlash">
+								<strong class="label label-warning"><cfoutput>#local.err.resource#</cfoutput></strong> should have a URI that begins with a forward slash.
 							<cfelse>
 								<strong class="label label-warning"><cfoutput>#local.err.resource#</cfoutput></strong> contains a syntax error.
 								<cfif structKeyExists(local.err.exception, 'tagContext')>

--- a/tests/resources/uriAliasDoesntBeginWithForwardSlash.cfc
+++ b/tests/resources/uriAliasDoesntBeginWithForwardSlash.cfc
@@ -1,0 +1,7 @@
+<cfcomponent extends="taffy.core.resource" taffy:uri="/uriWithForwardSlash{,},uriAliasWithoutFowardSlash">
+
+	<cffunction name="get">
+		<cfreturn noData() />
+	</cffunction>
+
+</cfcomponent>

--- a/tests/resources/uriDoesntBeginWithForwardSlash.cfc
+++ b/tests/resources/uriDoesntBeginWithForwardSlash.cfc
@@ -1,0 +1,7 @@
+<cfcomponent extends="taffy.core.resource" taffy:uri="uriWithoutForwardSlash">
+
+	<cffunction name="get">
+		<cfreturn noData() />
+	</cffunction>
+
+</cfcomponent>

--- a/tests/tests/TestConflict.cfc
+++ b/tests/tests/TestConflict.cfc
@@ -16,9 +16,7 @@
 		}
 
 		function conflicting_URIs_get_skipped() {
-			assertEquals(1, arrayLen(application._taffy.status.skippedResources), "Conflicting URIs not showing in errors");
-			var err = application._taffy.status.skippedResources[1];
-			assertEquals("taffy.resources.DuplicateUriPattern", local.err.Exception.ErrorCode);
+			assertTrue(checkIfOneSkippedRessourceContainsExpectedException("errorCode", "taffy.resources.DuplicateUriPattern"), "Conflicting URIs not showing in errors");
 		}
 	</cfscript>
 

--- a/tests/tests/TestCore.cfc
+++ b/tests/tests/TestCore.cfc
@@ -603,4 +603,12 @@
 		<cfset assertTrue(local.uploadResult.statusCode eq "200 OK", "Did not return status 200") />
 	</cffunction>
 
+	<cffunction name="throws_exception_when_ressource_uri_doesnt_begin_with_forward_slash">
+		<cfset assertTrue(checkIfOneSkippedRessourceContainsExpectedException("detail", "The URI (uriWithoutForwardSlash) for `uriDoesntBeginWithForwardSlash` should begin with a forward slash."), "Uri without forward slash not showing in errors")>
+	</cffunction>
+
+	<cffunction name="throws_exception_when_alias_ressource_uri_doesnt_begin_with_forward_slash">
+		<cfset assertTrue(checkIfOneSkippedRessourceContainsExpectedException("detail", "The URI (uriAliasWithoutFowardSlash) for `uriAliasDoesntBeginWithForwardSlash` should begin with a forward slash."), "Uri alias without forward slash not showing in errors")>
+	</cffunction>
+
 </cfcomponent>

--- a/tests/tests/base.cfc
+++ b/tests/tests/base.cfc
@@ -58,4 +58,20 @@
 		<cfreturn local.result />
 	</cffunction>
 
+	<cffunction name="checkIfOneSkippedRessourceContainsExpectedException" access="private" output="false" returntype="boolean">
+		<cfargument name="exceptionAttributeName" type="string" required="true" />
+		<cfargument name="expectedValue" type="string" required="true" />
+		<cfset var skippedRessource = "">
+		<cfset var expectedExceptionAttributeValueFound = 0>
+
+		<cfloop array="#application._taffy.status.skippedResources#" index="skippedRessource">
+			<cfset expectedExceptionAttributeValueFound = structKeyExists(skippedRessource.exception, arguments.exceptionAttributeName) and skippedRessource.exception[arguments.exceptionAttributeName] is arguments.expectedValue>
+			<cfif expectedExceptionAttributeValueFound>
+				<cfbreak>
+			</cfif>
+		</cfloop>
+
+		<cfreturn expectedExceptionAttributeValueFound>
+	</cffunction>
+
 </cfcomponent>


### PR DESCRIPTION
Added exception thrown when uri or uri alias is not starting with a forward slash, and added the tests accordingly. Changed the Dashboard to show this new error.