### PR TITLE
added checks for app and server-level mappings

### DIFF
--- a/core/api.cfc
+++ b/core/api.cfc
@@ -919,11 +919,28 @@
 	</cffunction>
 
 	<cffunction name="guessResourcesPath" access="private" output="false" returntype="string" hint="used to try and figure out the absolute path of the /resources folder even though this file may not be in the web root">
+		<!--- if /resources has been explicitly defined in an application mapping, it should take precedence --->
+		<cfif structKeyExists(this, "mappings")>
+			<!--- if app-level mappings are defined, server-level should be ignored entirely (hence the nested condition here) --->
+			<cfif structKeyExists(this.mappings, "/resources")>
+				<cfreturn "/resources" />
+			</cfif>
+		<cfelse>
+			<!--- check if a server-level mapping exists --->
+			<cfset local.serverMappings = createObject("java", "coldfusion.server.ServiceFactory").getRuntimeService().getMappings() />
+			<cfif structKeyExists(local.serverMappings, "/resources")>
+				<cfreturn "/resources" />
+			</cfif>
+		</cfif>
+
+		<!--- if all else fails, fall through to guessing where /resources lives --->
 		<cfset local.indexcfmpath = cgi.script_name />
 		<cfset local.resourcesPath = listDeleteAt(local.indexcfmpath, listLen(local.indexcfmpath, "/"), "/") & "/resources" />
-                <cfif GetContextRoot() NEQ "">
-                        <cfset local.resourcesPath = ReReplace(local.resourcesPath,"^#GetContextRoot()#","")>
-                </cfif>
+
+		<cfif GetContextRoot() NEQ "">
+			<cfset local.resourcesPath = ReReplace(local.resourcesPath,"^#GetContextRoot()#","")>
+		</cfif>
+
 		<cfreturn local.resourcesPath />
 	</cffunction>
 


### PR DESCRIPTION
@atuttle - I'm not sure about the server-level check, but given that this is only done when Taffy is initialized, it seems like this is an adequate fix. I tested application-level mappings, server-level mappings and the existing "guess" method in ACF11.

The ServiceFactory class is documented in Railo (http://www.getrailo.org/javadoc-4-0/coldfusion/server/RuntimeService.html), so I'm assuming it should work there as well.
