### PR TITLE
Fix for OpenBD compatibility regarding determining Query column names

### DIFF
--- a/core/resource.cfc
+++ b/core/resource.cfc
@@ -43,12 +43,12 @@
 		<cfargument name="cb" type="any" required="no" />
 		<cfscript>
 			var local = {};
-			if (structKeyExists(server, "railo")) {
+			if (not server.ColdFusion.ProductName eq "ColdFusion"){
 				local.Columns = listToArray(arguments.q.getColumnList(false));
-			}
-			else {
+			}else{
 				local.Columns = arguments.q.getMetaData().getColumnLabels();
 			}
+
 			local.QueryArray = ArrayNew(1);
 			for (local.RowIndex = 1; local.RowIndex <= arguments.q.RecordCount; local.RowIndex++){
 				local.Row = {};
@@ -78,10 +78,9 @@
 		</cfif>
 
 		<cfscript>
-			if (structKeyExists(server, "railo")) {
+			if (not server.ColdFusion.ProductName eq "ColdFusion"){
 				local.Columns = listToArray(arguments.q.getColumnList(false));
-			}
-			else {
+			}else{
 				local.Columns = arguments.q.getMetaData().getColumnLabels();
 			}
 

--- a/dashboard/dashboard.cfm
+++ b/dashboard/dashboard.cfm
@@ -216,7 +216,7 @@
 				<cfoutput>
 					<cfloop from="1" to="#arrayLen(application._taffy.uriMatchOrder)#" index="local.resource">
 						<cfset local.currentResource = application._taffy.endpoints[application._taffy.uriMatchOrder[local.resource]] />
-						<cfset local.resourceHTTPID = local.currentResource.beanName & "_" & hash(local.currentResource.srcURI) />
+						<cfset local.resourceHTTPID = replace(local.currentResource.beanName,"/","_","all") & "_" & hash(local.currentResource.srcURI) />
 						<div class="panel panel-default">
 							<div class="panel-heading">
 								<h4 class="panel-title">


### PR DESCRIPTION
OpenBD can use the same method as railo for determining column names, modded the resource.cfc to allow OpenBD to use the same logic as Railo and ColdFusion server to use the other method
