### PR TITLE
Removed potentially invalid characters from html div id

### DIFF
--- a/dashboard/dashboard.cfm
+++ b/dashboard/dashboard.cfm
@@ -216,7 +216,7 @@
 				<cfoutput>
 					<cfloop from="1" to="#arrayLen(application._taffy.uriMatchOrder)#" index="local.resource">
 						<cfset local.currentResource = application._taffy.endpoints[application._taffy.uriMatchOrder[local.resource]] />
-						<cfset local.resourceHTTPID = local.currentResource.beanName & "_" & hash(local.currentResource.srcURI) />
+						<cfset local.resourceHTTPID = rereplace(local.currentResource.beanName & "_" & hash(local.currentResource.srcURI), "[^0-9a-zA-Z_]", "_", "all") />
 						<div class="panel panel-default">
 							<div class="panel-heading">
 								<h4 class="panel-title">


### PR DESCRIPTION
Removed potentially invalid characters from html div id to allow the test form to be used when the bean name contains unusual characters.

The bean names for services in my application were named after their rest path. IE:

```
<bean id="/example/status" class="com.foo.bar.rest.example.status" />
```

The front slashes in the bean name were causing the a tag and the associated div tags to use invalid ids/names. I used a regex to reduce the generated ID to only use alphanumeric characters and underscore. This resolved the problem.