### PR TITLE
Patch for Error accessing dashboard Illegal target of jump or branch…

### DIFF
--- a/dashboard/dashboard.cfm
+++ b/dashboard/dashboard.cfm
@@ -337,45 +337,40 @@
 											<cfset local.func = local.docData.functions[local.f] />
 											<cfset local.found[local.func.name] = true />
 											<!--- exclude methods that are not exposed as REST verbs --->
-											<cfif !listFindNoCase('get,post,put,delete,patch',local.func.name) AND !structKeyExists(local.func,'taffy_verb') AND !structKeyExists(local.func,'taffy:verb')>
-												<cfif listfirst(SERVER.ColdFusion.ProductVersion) GTE 9>
-													<cfcontinue>
-												<cfelse>
-													<cfscript>continue;</cfscript><!--- stupid CF8 --->
+											<cfif listFindNoCase('get,post,put,delete,patch',local.func.name) OR structKeyExists(local.func,'taffy_verb') OR structKeyExists(local.func,'taffy:verb')>
+	 											<div class="col-md-12"><strong>#local.func.name#</strong></div>
+												<cfif structKeyExists(local.func, "hint")>
+													<div class="col-md-12 doc">#local.func.hint#</div>
 												</cfif>
-											</cfif>
- 											<div class="col-md-12"><strong>#local.func.name#</strong></div>
-											<cfif structKeyExists(local.func, "hint")>
-												<div class="col-md-12 doc">#local.func.hint#</div>
-											</cfif>
-											<cfloop from="1" to="#arrayLen(local.func.parameters)#" index="local.p">
-												<cfset local.param = local.func.parameters[local.p] />
-												<div class="row">
-													<div class="col-md-11 col-md-offset-1">
-															<cfif not structKeyExists(local.param, 'required') or not local.param.required>
-																optional
-															<cfelse>
-																required
-															</cfif>
-															<cfif structKeyExists(local.param, "type")>
-																#local.param.type#
-															</cfif>
-															<strong>#local.param.name#</strong>
-															<cfif structKeyExists(local.param, "default")>
-																<cfif local.param.default eq "">
-																	(default: "")
+												<cfloop from="1" to="#arrayLen(local.func.parameters)#" index="local.p">
+													<cfset local.param = local.func.parameters[local.p] />
+													<div class="row">
+														<div class="col-md-11 col-md-offset-1">
+																<cfif not structKeyExists(local.param, 'required') or not local.param.required>
+																	optional
 																<cfelse>
-																	(default: #local.param.default#)
+																	required
 																</cfif>
-															<cfelse>
-																<!--- no default value --->
+																<cfif structKeyExists(local.param, "type")>
+																	#local.param.type#
+																</cfif>
+																<strong>#local.param.name#</strong>
+																<cfif structKeyExists(local.param, "default")>
+																	<cfif local.param.default eq "">
+																		(default: "")
+																	<cfelse>
+																		(default: #local.param.default#)
+																	</cfif>
+																<cfelse>
+																	<!--- no default value --->
+																</cfif>
+															<cfif structKeyExists(local.param, "hint")>
+																<br/><span class="doc">#local.param.hint#</span>
 															</cfif>
-														<cfif structKeyExists(local.param, "hint")>
-															<br/><span class="doc">#local.param.hint#</span>
-														</cfif>
+														</div>
 													</div>
-												</div>
-											</cfloop>
+												</cfloop>
+											</cfif>
 										</cfloop>
 									</div><!-- /col-md-4 (docs) -->
 								</div>

--- a/dashboard/dashboard.cfm
+++ b/dashboard/dashboard.cfm
@@ -338,7 +338,11 @@
 											<cfset local.found[local.func.name] = true />
 											<!--- exclude methods that are not exposed as REST verbs --->
 											<cfif !listFindNoCase('get,post,put,delete,patch',local.func.name) AND !structKeyExists(local.func,'taffy_verb') AND !structKeyExists(local.func,'taffy:verb')>
-												<cfscript>continue;</cfscript><!--- stupid CF8 --->
+												<cfif listfirst(SERVER.ColdFusion.ProductVersion) GTE 9>
+													<cfcontinue>
+												<cfelse>
+													<cfscript>continue;</cfscript><!--- stupid CF8 --->
+												</cfif>
 											</cfif>
  											<div class="col-md-12"><strong>#local.func.name#</strong></div>
 											<cfif structKeyExists(local.func, "hint")>


### PR DESCRIPTION
Current Master branch running on CF9 on Windows 2008 R2 gives **Error accessing dashboard Illegal target of jump or branch** when attempting to access Taffy dashboard.

This issue is observable running CF9.0.1 CHF 1 on Java 1.6 on Windows 2008 R2, and is still observable running CF9.0.1 CHF4 on Java 1.7.

This issue is not observed on CF9.0.1 running on OSX.

Replacing the `continue;` statement within the `<cfscript>` block with `<cfcontinue>` resolves this issue.

As `<cfontinue>` is not supported on CF8, this statement has been wrapped in a conditional which will attempt to execute `<cfontinue>`  on CF >= 9, but will use the `continue;` statement within the `<cfscript>` block on CF8.

**This has only been tested on CF9 on windows and OSX - where it works without issue. 
It has not been tested on CF8 as I do not have access to a CF8 environment for testing.**