### PR TITLE
Add Lucee support to QueryToStruct

### DIFF
--- a/core/resource.cfc
+++ b/core/resource.cfc
@@ -78,7 +78,7 @@
 		</cfif>
 
 		<cfscript>
-			if (structKeyExists(server, "railo")) {
+			if (structKeyExists(server, "railo") or structKeyExists(server, "lucee")) {
 				local.Columns = listToArray(arguments.q.getColumnList(false));
 			}
 			else {


### PR DESCRIPTION
I'm starting to use Taffy on a Lucee server for a project and ran into an error with QueryToStruct and noticed that there is no check for the Lucee server in that method. I