### PR TITLE
https://github.com/atuttle/Taffy/issues/301

### DIFF
--- a/core/api.cfc
+++ b/core/api.cfc
@@ -1358,7 +1358,7 @@
 		<cfset local.credentials.password = "" />
 		<cftry>
 			<cfset local.encodedCredentials = ListLast( GetPageContext().getRequest().getHeader("Authorization"), " " ) />
-			<cfset local.decodedCredentials = toString( toBinary( local.EncodedCredentials ) ) />
+			<cfset local.decodedCredentials = toString( toBinary( local.EncodedCredentials ), "iso-8859-1" ) />
 			<cfset local.credentials.username = listFirst( local.decodedCredentials, ":" ) />
 			<cfset local.credentials.password = listRest( local.decodedCredentials, ":" ) />
 			<cfcatch></cfcatch>


### PR DESCRIPTION
BASIC auth is ISO encoded Base64, and toString() decodes it with UTF-8. Changed to use "iso-8859-1"