### PR TITLE
Stop Taffy intercepting requests in ignored folders when applicaton starting up

### DIFF
--- a/core/api.cfc
+++ b/core/api.cfc
@@ -83,7 +83,7 @@
 			(
 				application._taffy.settings.reloadOnEveryRequest eq true
 			)>
-			<cfif !local.reloadedInThisRequest><!--- prevent double reloads --->
+			<cfif !local.reloadedInThisRequest and !isUnhandledPathRequest(arguments.targetPath)><!--- prevent double reloads --->
 				<cfset onApplicationStart() />
 			</cfif>
 		</cfif>


### PR DESCRIPTION
If Taffy should not handle this request, do not call it's onApplicationStart() even if reloadEveryRequest is true or the URL keys match