### PR TITLE
Adding Status code onTaffyRequestEnd

### DIFF
--- a/core/api.cfc
+++ b/core/api.cfc
@@ -491,6 +491,7 @@
 			,local.parsed.matchDetails.srcUri
 			,structKeyExists( _taffyRequest, 'resultSerialized' ) ? _taffyRequest.resultSerialized : ''
 			,structKeyExists( _taffyRequest, 'result' ) ? _taffyRequest.result.getData() : {}
+			,_taffyRequest.statusArgs.statusCode
 			) />
 		<cfset m.otreTime = getTickCount() - m.beforeOnTaffyRequestEnd />
 		<cfheader name="X-TIME-IN-ONTAFFYREQUESTEND" value="#m.otreTime#" />

--- a/core/api.cfc
+++ b/core/api.cfc
@@ -34,6 +34,7 @@
 		<cfargument name="matchedURI" />
 		<cfargument name="parsedResponse" />
 		<cfargument name="originalResponse" />
+		<cfargument name="statusCode"	/>
 		<cfreturn true />
 	</cffunction>
 


### PR DESCRIPTION
The onTaffyRequestEnd function  is really useful for separating resources and logging request/response. Avoiding duplication of code to log endpoint response.

In this change we returned status code to onTaffyRequestEnd for us to capture the status code returned by the resources.