### PR TITLE
CF8 Ternary Operator Compatibility in api.cfc

### DIFF
--- a/core/api.cfc
+++ b/core/api.cfc
@@ -480,6 +480,16 @@
 			</cfif>
 		</cfif>
 
+		<cfset local.resultSerialized = "" />
+		<cfif structKeyExists( _taffyRequest, "resultSerialized" )>
+			<cfset local.resultSerialized = _taffyRequest.resultSerialized />
+		</cfif>
+
+		<cfset local.result = StructNew() />
+		<cfif structKeyExists( _taffyRequest, "result" )>
+			<cfset local.result = _taffyRequest.result.getData() />
+		</cfif>
+
 		<!--- ...after the service has finished... --->
 		<cfset m.beforeOnTaffyRequestEnd = getTickCount() />
 		<cfset onTaffyRequestEnd(
@@ -490,8 +500,8 @@
 			,_taffyRequest.headers
 			,_taffyRequest.methodMetadata
 			,local.parsed.matchDetails.srcUri
-			,IIf((structKeyExists( _taffyRequest, 'resultSerialized')), _taffyRequest.resultSerialized, '')
-			,IIf((structKeyExists( _taffyRequest, 'result')), _taffyRequest.result.getData(), StructNew())
+			,local.resultSerialized
+			,local.result
 			,_taffyRequest.statusArgs.statusCode
 			) />
 		<cfset m.otreTime = getTickCount() - m.beforeOnTaffyRequestEnd />

--- a/core/api.cfc
+++ b/core/api.cfc
@@ -490,8 +490,8 @@
 			,_taffyRequest.headers
 			,_taffyRequest.methodMetadata
 			,local.parsed.matchDetails.srcUri
-			,structKeyExists( _taffyRequest, 'resultSerialized' ) ? _taffyRequest.resultSerialized : ''
-			,structKeyExists( _taffyRequest, 'result' ) ? _taffyRequest.result.getData() : {}
+			,IIf((structKeyExists( _taffyRequest, 'resultSerialized')), _taffyRequest.resultSerialized, '')
+			,IIf((structKeyExists( _taffyRequest, 'result')), _taffyRequest.result.getData(), StructNew())
 			,_taffyRequest.statusArgs.statusCode
 			) />
 		<cfset m.otreTime = getTickCount() - m.beforeOnTaffyRequestEnd />


### PR DESCRIPTION
I realize this is for a very old version of CF, but the latest Taffy 3.1.0 won't run out of the box on CF8 (our current version) as it doesn't support the ternary operator. This change resolves that at the expense of using IIf() which may have performance impacts, etc. Perhaps this has been addressed in some other way (an alternate version of Taffy?), but for people stuck on CF8, this may be helpful, since the latest Taffy claims CF8 compatibility.

Additionally, StructNew() is used here as {} throws a "Missing argument name. When using named parameters to a function, every parameter must have a name." error.

Server Product  ColdFusion
Version     8,0,1,195765  
Edition     Developer  
Serial Number   Developer  
Operating System    UNIX  
OS Version  3.0.101-0.7.17-default  
JVM Details
Java Version    1.6.0_04
