### PR TITLE
Example Upload destination getTempDirectory()

### DIFF
--- a/examples/api_uploadImg/resources/imageCollection.cfc
+++ b/examples/api_uploadImg/resources/imageCollection.cfc
@@ -7,7 +7,7 @@
 
 		<cffile
 			action="upload"
-			destination="#expandPath('/taffy/examples/api_uploadImg/_scratch/')#"
+			destination="#getTempDirectory()#"
 			fileField="img"
 			nameConflict="MakeUnique"
 			result="local.uploadResult"


### PR DESCRIPTION
Setting destination to `getTempDirectory()` by default instead of expandPath under the web root.