### PR TITLE
Update dash.js to properly URI encode URLs

### DIFF
--- a/dashboard/dash.js
+++ b/dashboard/dash.js
@@ -60,7 +60,7 @@ $(function(){
 				delete tokens[t];
 		}
 		var result = uri.supplant(tokens);
-		result += (q.length) ? '?' + decodeURIComponent(q) : '';
+		result += (q.length) ? '?' + q : '';
 		resource.find('.resourceUri').val(result);
 	});
 


### PR DESCRIPTION
When entering a qparam value for a resource in the dashboard, strings are not properly encoded in the resourceURI fields. During the queryparam creation, the values are correct, but they are then decoded before being placed in the URI field. This will cause key values like this:

`/resource?apikey=eN+W/tydEqyG6VhsLzBoOqCmIlFg7PB5MIoKFmZiw6k=`

To *not* be escaped, and they are no longer value URLs. Removing the decodeuri function will instead put the following into the URI field:

`/resource?apikey=eN%2BW%2FtydEqyG6VhsLzBoOqCmIlFg7PB5MIoKFmZiw6k%3D`