### PR TITLE
Update docs.cfm to correct bad collapse behavior

### DIFF
--- a/dashboard/docs.cfm
+++ b/dashboard/docs.cfm
@@ -38,7 +38,7 @@
 									<code style="float:right; margin-top: -15px; display: inline-block;">#local.currentResource.srcUri#</code>
 								</h4>
 							</div>
-							<div id="#local.currentResource.beanName#">
+							<div id="#local.currentResource.beanName#" class="in">
 								<div class="panel-body resourceWrapper">
 									<div class="col-md-12 docs">
 										<cfset local.metadata = getMetaData(application._taffy.factory.getBean(local.currentResource.beanName)) />


### PR DESCRIPTION
On initial load, clicking the heading for a resource will attempt to expand the panel, when it is already expanded. A second click will then collapse the panel, and behavior will return to normal.

Added `class="in"` to the resource section of each panel so that the initial click on a heading will properly collapse the panel.

This could probably use a bit more work to ensure that the group behavior is polished.