### PR TITLE
`withStatus()` lookup `statusText` based on `statusCode`

### DIFF
--- a/core/baseSerializer.cfc
+++ b/core/baseSerializer.cfc
@@ -14,6 +14,70 @@
 	<cfset variables.types[2] = "filename" />
 	<cfset variables.types[3] = "filedata" />
 	<cfset variables.types[4] = "imagedata" />
+	<cfset variables.statusTexts = StructNew() />
+	<cfset variables.statusTexts[100] = "Continue" />
+	<cfset variables.statusTexts[101] = "Switching Protocols" />
+	<cfset variables.statusTexts[102] = "Processing" />
+	<cfset variables.statusTexts[200] = "OK" />
+	<cfset variables.statusTexts[201] = "Created" />
+	<cfset variables.statusTexts[202] = "Accepted" />
+	<cfset variables.statusTexts[203] = "Non-authoritative Information" />
+	<cfset variables.statusTexts[204] = "No Content" />
+	<cfset variables.statusTexts[205] = "Reset Content" />
+	<cfset variables.statusTexts[206] = "Partial Content" />
+	<cfset variables.statusTexts[207] = "Multi-Status" />
+	<cfset variables.statusTexts[208] = "Already Reported" />
+	<cfset variables.statusTexts[226] = "IM Used" />
+	<cfset variables.statusTexts[300] = "Multiple Choices" />
+	<cfset variables.statusTexts[301] = "Moved Permanently" />
+	<cfset variables.statusTexts[302] = "Found" />
+	<cfset variables.statusTexts[303] = "See Other" />
+	<cfset variables.statusTexts[304] = "Not Modified" />
+	<cfset variables.statusTexts[305] = "Use Proxy" />
+	<cfset variables.statusTexts[307] = "Temporary Redirect" />
+	<cfset variables.statusTexts[308] = "Permanent Redirect" />
+	<cfset variables.statusTexts[400] = "Bad Request" />
+	<cfset variables.statusTexts[401] = "Unauthorized" />
+	<cfset variables.statusTexts[402] = "Payment Required" />
+	<cfset variables.statusTexts[403] = "Forbidden" />
+	<cfset variables.statusTexts[404] = "Not Found" />
+	<cfset variables.statusTexts[405] = "Method Not Allowed" />
+	<cfset variables.statusTexts[406] = "Not Acceptable" />
+	<cfset variables.statusTexts[407] = "Proxy Authentication Required" />
+	<cfset variables.statusTexts[408] = "Request Timeout" />
+	<cfset variables.statusTexts[409] = "Conflict" />
+	<cfset variables.statusTexts[410] = "Gone" />
+	<cfset variables.statusTexts[411] = "Length Required" />
+	<cfset variables.statusTexts[412] = "Precondition Failed" />
+	<cfset variables.statusTexts[413] = "Payload Too Large" />
+	<cfset variables.statusTexts[414] = "Request-URI Too Long" />
+	<cfset variables.statusTexts[415] = "Unsupported Media Type" />
+	<cfset variables.statusTexts[416] = "Requested Range Not Satisfiable" />
+	<cfset variables.statusTexts[417] = "Expectation Failed" />
+	<cfset variables.statusTexts[418] = "I'm a teapot" />
+	<cfset variables.statusTexts[421] = "Misdirected Request" />
+	<cfset variables.statusTexts[422] = "Unprocessable Entity" />
+	<cfset variables.statusTexts[423] = "Locked" />
+	<cfset variables.statusTexts[424] = "Failed Dependency" />
+	<cfset variables.statusTexts[426] = "Upgrade Required" />
+	<cfset variables.statusTexts[428] = "Precondition Required" />
+	<cfset variables.statusTexts[429] = "Too Many Requests" />
+	<cfset variables.statusTexts[431] = "Request Header Fields Too Large" />
+	<cfset variables.statusTexts[444] = "Connection Closed Without Response" />
+	<cfset variables.statusTexts[451] = "Unavailable For Legal Reasons" />
+	<cfset variables.statusTexts[499] = "Client Closed Request" />
+	<cfset variables.statusTexts[500] = "Internal Server Error" />
+	<cfset variables.statusTexts[501] = "Not Implemented" />
+	<cfset variables.statusTexts[502] = "Bad Gateway" />
+	<cfset variables.statusTexts[503] = "Service Unavailable" />
+	<cfset variables.statusTexts[504] = "Gateway Timeout" />
+	<cfset variables.statusTexts[505] = "HTTP Version Not Supported" />
+	<cfset variables.statusTexts[506] = "Variant Also Negotiates" />
+	<cfset variables.statusTexts[507] = "Insufficient Storage" />
+	<cfset variables.statusTexts[508] = "Loop Detected" />
+	<cfset variables.statusTexts[510] = "Not Extended" />
+	<cfset variables.statusTexts[511] = "Network Authentication Required" />
+	<cfset variables.statusTexts[599] = "Network Connect Timeout Error" />
 
 	<cffunction name="getType" acces="public" output="false">
 		<cfreturn variables.types[variables.type] />
@@ -86,6 +150,8 @@
 		<cfset variables.statusCode = arguments.statusCode />
 		<cfif len(arguments.statusText)>
 			<cfset variables.statusText = arguments.statusText />
+		<cfelseif StructKeyExists(variables.statusTexts, arguments.statusCode)>
+			<cfset variables.statusText = variables.statusTexts[arguments.statusCode] />
 		</cfif>
 		<cfreturn this />
 	</cffunction>

--- a/tests/tests/TestRepresentations.cfc
+++ b/tests/tests/TestRepresentations.cfc
@@ -23,6 +23,13 @@
 		assertEquals(42, variables.serializer.getStatus());
 	}
 
+	function test_withStatus_getStatusText(){
+		variables.serializer.withStatus(404, "Not Found");
+		assertEquals("Not Found", variables.serializer.getStatusText());
+		variables.serializer.withStatus(418);
+		assertEquals("I'm a teapot", variables.serializer.getStatusText());
+	}
+
 	function test_withHeaders_getHeaders(){
 		local.h = {};
 		local.h['x-dude'] = 'dude!';


### PR DESCRIPTION
If no `statusText` is passed into `withStatus()`, then lookup what the "standard" status text would be based on the (required) `statusCode`. The list of codes and texts were pulled from https://httpstatuses.com/

P.S. Taking a cue from `variables.types` on how to setup the struct/map on the serializer. A test was also added for this functionality.

This would resolve #329 