### PR TITLE
Add support for jsonapi in dashboard response json

### DIFF
--- a/dashboard/dash.js
+++ b/dashboard/dash.js
@@ -134,7 +134,7 @@ $(function(){
 			reset.show();
 			headers = parseHeaders(headers);
 
-			if (headers['content-type'].indexOf('application/json') > -1 || headers['content-type'].indexOf('text/json') > -1){
+			if (headers['content-type'].indexOf('application/json') > -1 || headers['content-type'].indexOf('text/json') > -1 || headers['content-type'].indexOf('application/vnd.api+json') > -1){
 				//indentation!
 				if (body.length){
 					body = JSON.stringify(JSON.parse(body), null, 3);


### PR DESCRIPTION
If a jsonapi ([jsonapi.org](http://jsonapi.org)) content type (application/vnd.api+json) is specified as the taffy_mime in the serializer then the json is now correctly formatted in the dashboard output.