### PR TITLE
Handle case where a parameter may be passed more than once.

### DIFF
--- a/core/baseDeserializer.cfc
+++ b/core/baseDeserializer.cfc
@@ -8,6 +8,8 @@
 		<cfset var pair = "" />
 		<cfset var kv = [] />
 		<cfset var ix = 0 />
+		<cfset var k = "" />
+		<cfset var v = "" />
 
 		<cfif not find('=', arguments.body)>
 			<cfset throwError(400, "You've indicated that you're sending form-encoded data but it doesn't appear to be valid. Aborting request.") />
@@ -16,7 +18,13 @@
 		<cfloop from="1" to="#arrayLen(pairs)#" index="ix">
 			<cfset pair = pairs[ix] />
 			<cfset kv = listToArray(pair, "=", true) />
-			<cfset response[kv[1]] = urlDecode( kv[2] ) />
+			<cfset k = kv[1] />
+			<cfset v = urlDecode( kv[2] ) />
+			<cfif structKeyExists( response, k )>
+				<cfset response[k] = listAppend(response[k], v)>
+			<cfelse>
+				<cfset response[k] = v>
+			</cfif>
 		</cfloop>
 
 		<cfreturn response />


### PR DESCRIPTION
Handle case where a parameter may be passed more than once.

On Adobe ColdFusion a request sent with `application/x-www-form-urlencoded` gives a body such as:

'foo=1%2C2%2C3&foo=20&foo=30'

For a POST request you get:

"foo":"1,2,3,20,30"

For PUT / PATCH / DELETE requests you get:

"foo":30"

Tested on ACF 2016. Also tested on Lucee 5 which is not affected by the above issue (as Lucee populates the form scope for PUT / PATCH / DELETE requests), and does not break with this proposed patch.

Example cURL requests:

curl --request PATCH \
  --url 'http://127.0.0.1:43998/taffy/examples/api/index.cfm?endpoint=%2Fping' \
  --header 'cache-control: no-cache' \
  --header 'content-type: application/x-www-form-urlencoded' \
  --header 'postman-token: 7cb10378-8079-356b-9ae7-54677e308a21' \
  --data 'foo=1%2C2%2C3&foo=20&foo=30'

curl --request POST \
  --url 'http://127.0.0.1:43998/taffy/examples/api/index.cfm?endpoint=%2Fping' \
  --header 'cache-control: no-cache' \
  --header 'content-type: application/x-www-form-urlencoded' \
  --header 'postman-token: dddecf0e-cd46-d9eb-bced-ec04c988e950' \
  --data 'foo=1%2C2%2C3&foo=20&foo=30'

Ping resource is a simple:

```
component extends="taffy.core.resource" taffy_uri="/ping" {

	function post() {
		arguments._verb = "post";
		return rep(arguments);
	}
	function put() {
		arguments._verb = "put";
		return rep(arguments);
	}
	function patch() {
		arguments._verb = "patch";
		return rep(arguments);
	}
	function delete() {
		arguments._verb = "delete";
		return rep(arguments);
	}

}
```
