### PR TITLE
Fix for http body containing null

### DIFF
--- a/core/api.cfc
+++ b/core/api.cfc
@@ -685,7 +685,7 @@
 
 		<cfset requestObj.body = getRequestBody() />
 		<cfset requestObj.contentType = cgi.content_type />
-		<cfif len(requestObj.body)>
+		<cfif len(requestObj.body) AND requestObj.body != "null">
 			<cfif findNoCase("multipart/form-data", requestObj.contentType)>
 				<!--- do nothing, to support the way railo handles multipart requests (just avoids the error condition below) --->
 				<cfset requestObj.queryString = cgi.query_string />


### PR DESCRIPTION
Fix for **variable [DATA] does not exist on line 12** within core.nativeJsonDeserializer when attempting to process a request with http body == null and Content-Type == application/json

See https://trycf.com/editor/gist/cc470e44e847c08f2bc455cd3914a7ee/lucee5?theme=monokai for reproduction.

Bug experienced within Lucee 5.2.4.35-RC on Java 1.8.0_144, with the following http request:

`DELETE /company/23605856-B653-4492-90A4-90C942896B1A HTTP/1.1
Authorization: ***** Hidden credentials *****
Content-Type: application/json
Host: ***** Hidden host *****
Connection: close
User-Agent: Paw/3.1.4 (Macintosh; OS X/10.11.6) GCDHTTPRequest
Content-Length: 4

null`

Same application did not exhibit this behaviour when running on Adobe CF 9.0.1 on Java 1.6.0_24, although this was with an earlier version of Taffy (#296713ab0fc08e08de88868f508caf893e52cf41)