### PR TITLE
Allow renaming and hiding of resources in dashboard/docs

### DIFF
--- a/dashboard/dashboard.cfm
+++ b/dashboard/dashboard.cfm
@@ -181,11 +181,25 @@
 					<cfloop from="1" to="#arrayLen(application._taffy.uriMatchOrder)#" index="local.resource">
 						<cfset local.currentResource = application._taffy.endpoints[application._taffy.uriMatchOrder[local.resource]] />
 						<cfset local.resourceHTTPID = rereplace(local.currentResource.beanName & "_" & hash(local.currentResource.srcURI), "[^0-9a-zA-Z_]", "_", "all") />
+						<cfset local.md = getMetaData(application._taffy.factory.getBean(local.currentResource.beanName)) />
+						<cfif structKeyExists(local.md, "taffy_dashboard_hide") OR structKeyExists(local.md, "taffy:dashboard:hide")>
+							<cfscript>continue;</cfscript>
+						</cfif>
 						<div class="panel panel-default">
 							<div class="panel-heading">
 								<h4 class="panel-title">
 									<a href="###local.resourceHTTPID#" class="accordion-toggle" data-toggle="collapse" data-parent="##resourcesAccordion">
-										#local.currentResource.beanName#
+										<cfif structKeyExists(local.md, "taffy:dashboard:name")>
+											#local.md['taffy:dashboard:name']#
+										<cfelseif structKeyExists(local.md, "taffy_dashboard_name")>
+											#local.md['taffy_dashboard_name']#
+										<cfelseif structKeyExists(local.md, "taffy:docs:name")>
+											#local.md['taffy:docs:name']#
+										<cfelseif structKeyExists(local.md, "taffy_docs_name")>
+											#local.md['taffy_docs_name']#
+										<cfelse>
+											#local.currentResource.beanName#
+										</cfif>
 									</a>
 									<cfloop list="DELETE|warning,PATCH|warning,PUT|warning,POST|danger,GET|primary" index="local.verb">
 										<cfif structKeyExists(local.currentResource.methods, listFirst(local.verb,'|'))>
@@ -288,7 +302,6 @@
 											<div class="reqBody">
 												<h4>Request Body:</h4>
 												<textarea id="#local.resourceHTTPID#_RequestBody" class="form-control input-sm" rows="5"></textarea>
-												<cfset local.md = getMetaData(application._taffy.factory.getBean(local.currentResource.beanName)) />
 												<cfif structKeyExists(local.md,"functions")>
 													<cfset local.functions = local.md.functions />
 												<cfelse>

--- a/dashboard/docs.cfm
+++ b/dashboard/docs.cfm
@@ -25,15 +25,20 @@
 					<cfloop from="1" to="#arrayLen(application._taffy.uriMatchOrder)#" index="local.resource">
 						<cfset local.currentResource = application._taffy.endpoints[application._taffy.uriMatchOrder[local.resource]] />
 						<cfset local.beanMeta = getMetaData(application._taffy.factory.getBean(local.currentResource.beanName)) />
-						<cfif structKeyExists(local.beanMeta, "taffy_docs_hide")
-								OR structKeyExists(local.beanMeta, "taffy:docs:hide")>
+						<cfif structKeyExists(local.beanMeta, "taffy_docs_hide") OR structKeyExists(local.beanMeta, "taffy:docs:hide")>
 							<cfscript>continue;</cfscript>
 						</cfif>
 						<div class="panel panel-default">
 							<div class="panel-heading">
 								<h4 class="panel-title">
 									<a href="###local.currentResource.beanName#" class="accordion-toggle" data-toggle="collapse" data-parent="##resourcesAccordion">
-										#local.currentResource.beanName#
+										<cfif structKeyExists(local.beanMeta, "taffy:docs:name")>
+											#local.beanMeta['taffy:docs:name']#
+										<cfelseif structKeyExists(local.beanMeta, "taffy_docs_name")>
+											#local.beanMeta['taffy_docs_name']#
+										<cfelse>
+											#local.currentResource.beanName#
+										</cfif>
 									</a>
 									<cfloop list="DELETE|warning,PATCH|warning,PUT|warning,POST|danger,GET|primary" index="local.verb">
 										<cfif structKeyExists(local.currentResource.methods, listFirst(local.verb,'|'))>


### PR DESCRIPTION
Resolves #316
Resolves #288

It seems that as of CF11 the script component syntax doesn't like component metadata with two colons, like `taffy:docs:hide` or `taffy:dashboard:name`... sigh. (This syntax does work in tag components, but why on earth would you want to write those??) This is why we can't have nice things, Adobe.

So continuing the tradition of ugliness:

- `taffy:docs:hide` ~= `taffy_docs_hide`
- `taffy:docs:name="foo"` ~= `taffy_docs_name="foo"`
- `taffy:dashboard:name="bar"` ~= `taffy_dashboard_name="bar"`
- `taffy:dashboard:hide` ~= `taffy_dashboard_hide`

When displaying in the dashboard, if `taffy:dashboard:name` is not defined but `taffy:docs:name` is, the latter will be used as the display name. In the documentation, `taffy:dashboard:name` is never checked. In both locations, if an override is not found, the beanName is displayed instead (current behavior).