### PR TITLE
add csrf token logic

### DIFF
--- a/core/api.cfc
+++ b/core/api.cfc
@@ -563,6 +563,9 @@
 		<cfset local.defaultConfig.returnExceptionsAsJson = true />
 		<cfset local.defaultConfig.exceptionLogAdapter = "taffy.bonus.LogToDevNull" />
 		<cfset local.defaultConfig.exceptionLogAdapterConfig = StructNew() />
+		<cfset local.defaultConfig.csrfToken = structNew() />
+		<cfset local.defaultConfig.csrfToken.cookieName = "" />
+		<cfset local.defaultConfig.csrfToken.headerName = "" />
 		<!--- status --->
 		<cfset local._taffy.status = structNew() />
 		<cfset local._taffy.status.internalBeanFactoryUsed = false />

--- a/dashboard/dashboard.cfm
+++ b/dashboard/dashboard.cfm
@@ -502,9 +502,16 @@
 			var dType = null;
 
 			<cfif Len(application._taffy.settings.csrfToken.cookieName) AND Len(application._taffy.settings.csrfToken.headerName)>
-				var csrfCookie = getCookie('<cfoutput>#application._taffy.settings.csrfToken.cookieName#</cfoutput>');
+				<cfif structKeyExists(GetFunctionList(), "encodeForJavascript")>
+					<cfset local.csrfCookieName = encodeForJavascript(application._taffy.settings.csrfToken.cookieName)>
+					<cfset local.csrfHeaderName = encodeForJavascript(application._taffy.settings.csrfToken.headerName)>
+				<cfelse>
+					<cfset local.csrfCookieName = jsStringFormat(application._taffy.settings.csrfToken.cookieName)>
+					<cfset local.csrfHeaderName = jsStringFormat(application._taffy.settings.csrfToken.headerName)>
+				</cfif>
+				var csrfCookie = getCookie('<cfoutput>#local.csrfCookieName#</cfoutput>');
 				if (csrfCookie) {
-					headers['<cfoutput>#application._taffy.settings.csrfToken.headerName#</cfoutput>'] = csrfCookie;
+					headers['<cfoutput>#local.csrfHeaderName#</cfoutput>'] = csrfCookie;
 				}
 			</cfif>
 

--- a/dashboard/dashboard.cfm
+++ b/dashboard/dashboard.cfm
@@ -501,6 +501,13 @@
 			var args = '';
 			var dType = null;
 
+			<cfif Len(application._taffy.settings.csrfToken.cookieName) AND Len(application._taffy.settings.csrfToken.headerName)>
+				var csrfCookie = getCookie('<cfoutput>#application._taffy.settings.csrfToken.cookieName#</cfoutput>');
+				if (csrfCookie) {
+					headers['<cfoutput>#application._taffy.settings.csrfToken.headerName#</cfoutput>'] = csrfCookie;
+				}
+			</cfif>
+
 			url += '<cfoutput>#cgi.SCRIPT_NAME#</cfoutput>' + '?' + endpointURLParam + '=' + encodeURIComponent(endpoint);
 			if( resource.indexOf('?') && resource.split('?')[1] ){
 				url += '&' + resource.split('?')[1];
@@ -534,6 +541,16 @@
 					, xhr.responseText							//body
 				);
 			});
+		}
+
+		function getCookie(name) {
+			var nameEQ = name + '=', ca = document.cookie.split(';'), i = 0, c;
+				for(;i < ca.length;i++) {
+					c = ca[i];
+					while (c[0]==' ') c = c.substring(1);
+					if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length);
+				}
+			return null;
 		}
 	</script>
 </body>


### PR DESCRIPTION
Some Frontend Frameworks use some automatic CSRF logic (e.g. Angular is looking for a cookie named XSRF-TOKEN and automatically add it to the request header as X-XSRF-TOKEN). If this check is added to onTaffyRequest() the dashboard would require to add this value manually for each request.

This PR is adding new settings to name the cookie and the header and if both filled the dashboard will process it.