### PR TITLE
 noData() sends invalid response #365

### DIFF
--- a/core/api.cfc
+++ b/core/api.cfc
@@ -1338,6 +1338,10 @@
 		<cfreturn newRepresentation().noData() />
 	</cffunction>
 
+	<cffunction name="noContent" access="public" output="false">
+		<cfreturn newRepresentation().noContent() />
+	</cffunction>
+
 	<cffunction name="representationOf" access="public" output="false">
 		<cfargument name="data" required="true" />
 		<cfreturn newRepresentation().setData( arguments.data ) />

--- a/core/api.cfc
+++ b/core/api.cfc
@@ -558,6 +558,7 @@
 		<cfset local.defaultConfig.allowCrossDomain = false />
 		<cfset local.defaultConfig.useEtags = false />
 		<cfset local.defaultConfig.jsonp = false />
+		<cfset local.defaultConfig.noDataSends204NoContent = false />
 		<cfset local.defaultConfig.globalHeaders = structNew() />
 		<cfset local.defaultConfig.mimeTypes = structNew() />
 		<cfset local.defaultConfig.returnExceptionsAsJson = true />

--- a/core/baseSerializer.cfc
+++ b/core/baseSerializer.cfc
@@ -98,6 +98,14 @@
 		<cfreturn this />
 	</cffunction>
 
+	<cffunction name="noContent" access="public" output="false" hint="returns empty representation instance">
+		<!--- According to issue #365 https://github.com/atuttle/Taffy/issues/365
+				noContent() returns with HTTP status code 204 and Content-Type as text/plain (omitting this header is difficult and maybe not recommanded)
+				noData() is kept 'as is' for backward compatibility with existing implementations
+		--->
+		<cfreturn this.withStatus(204).withHeaders({"Content-Type":"text/plain"}) />
+	</cffunction>
+
 	<cffunction name="setFileName" access="public" output="false" hint="Pass in a file-name (fully qualified, e.g. c:\temp\img.jpg) to have Taffy stream this file back to the client">
 		<cfargument name="file" type="string" required="true" />
 		<cfset variables.type = 2 />

--- a/core/baseSerializer.cfc
+++ b/core/baseSerializer.cfc
@@ -95,7 +95,11 @@
 	</cffunction>
 
 	<cffunction name="noData" access="public" output="false" hint="returns empty representation instance">
-		<cfreturn this />
+		<cfif application._taffy.settings.noDataSends204NoContent>
+			<cfreturn this.noContent() />
+		<cfelse>
+			<cfreturn this />
+		</cfif>
 	</cffunction>
 
 	<cffunction name="noContent" access="public" output="false" hint="returns empty representation instance">

--- a/core/resource.cfc
+++ b/core/resource.cfc
@@ -23,6 +23,10 @@
 		<cfreturn getRepInstance().noData() />
 	</cffunction>
 
+	<cffunction name="noContent" access="private" output="false" hint="use this function to return only headers to the consumer, no data">
+		<cfreturn getRepInstance().noContent() />
+	</cffunction>
+
 	<cffunction name="streamFile" access="private" output="false" hint="Use this function to specify a file name (eg c:\tmp\kitten.jpg) to be streamed to the client. When you use this method it is *required* that you also use .withMime() to specify the mime type.">
 		<cfargument name="fileName" required="true" hint="fully qualified file path (eg c:\tmp\kitten.jpg)" />
 		<cfreturn getRepInstance().setFileName(arguments.fileName) />


### PR DESCRIPTION
- added a noContent() function that enhance the noData() one by sending back 204 HTTP Status and text/plain Content-Type to avoid misinterpretation of empty json content
- added noDataSends204NoContent framework setting to force noData to behave like noContent