### PR TITLE
Filled out box.json

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,7 +1,7 @@
 {
     "name": "Taffy",
     "shortDescription": "REST Web Service framework for ColdFusion and Lucee",
-    "slug": "Taffy",
+    "slug": "taffy",
     "author": "Adam Tuttle",
     "version": "3.2.0",
     "homepage": "http://taffy.io/",

--- a/box.json
+++ b/box.json
@@ -1,27 +1,56 @@
 {
-    "name":"Taffy",
-    "shortDescription":"REST Web Service framework for ColdFusion and Lucee",
-    "slug":"Taffy",
-    "author":"Adam Tuttle",
-    "location":"https://github.com/atuttle/taffy",
-    "Homepage":"http://taffy.io/",
-    "Documentation":"http://docs.taffy.io/",
-    "type":"mvc",
-    "Repository":{
-        "type":"git",
-        "URL":"https://github.com/atuttle/taffy.git"
+    "name": "Taffy",
+    "shortDescription": "REST Web Service framework for ColdFusion and Lucee",
+    "slug": "Taffy",
+    "author": "Adam Tuttle",
+    "version": "3.2.0",
+    "homepage": "http://taffy.io/",
+    "documentation": "http://docs.taffy.io/",
+    "type": "mvc",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/atuttle/taffy.git"
     },
-    "devDependencies":{
-        "testbox":"^2.5.0+107",
-        "commandbox-cfconfig":"be",
-        "di1":"git+https://github.com/framework-one/di1.git",
-        "hoth":"git+https://github.com/aarongreenlee/Hoth.git",
-        "BugLogHQ":"git+https://github.com/oarevalo/BugLogHQ.git"
+    "bugs": "https://github.com/atuttle/Taffy/issues",
+    "license": [
+        {
+            "type": "MIT",
+            "url": "https://raw.githubusercontent.com/atuttle/Taffy/master/LICENSE.TXT"
+        }
+    ],
+    "devDependencies": {
+        "testbox": "^2.5.0+107",
+        "commandbox-cfconfig": "be",
+        "di1": "git+https://github.com/framework-one/di1.git",
+        "hoth": "git+https://github.com/aarongreenlee/Hoth.git",
+        "BugLogHQ": "git+https://github.com/oarevalo/BugLogHQ.git"
     },
-    "installPaths":{
-        "testbox":"tests/testbox/",
-        "di1":"tests/di1/",
-        "Hoth":"tests/Hoth/",
-        "BugLogHQ":"tests/BugLogHQ"
-    }
+    "installPaths": {
+        "testbox": "tests/testbox/",
+        "di1": "tests/di1/",
+        "Hoth": "tests/Hoth/",
+        "BugLogHQ": "tests/BugLogHQ"
+    },
+    "engines": [
+        {
+            "type": "lucee",
+            "version": ">=4.5.x"
+        },
+        {
+            "type": "adobe",
+            "version": ">=8.0.0"
+        }
+    ],
+    "ignore": [
+        "examples/",
+        "lib/",
+        "snippets/",
+        "tests/",
+        ".cfconfig.json",
+        ".gitignore",
+        ".travis.yml",
+        "CONTRIBUTING.md",
+        "build.xml",
+        "server.json"
+    ]
 }


### PR DESCRIPTION
Filled out `box.json` to improve the experience when using the repository as a dependency endpoint with CommandBox. This could also be used to publish to ForgeBox if the interest arises (and ownership is transferred).

* Ignores files that are unnecessary for deployment
* Lowercased slug so that default installation folder matches docs
* Other changes that would really only matter for ForgeBox
* Formatting