### PR TITLE
Fixed the Travis-CI Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ install:
 - cfmatrix/bin/box recipe recipeFile=cfmatrix/ci.boxr CFENGINE=$CFENGINE
 - mysql buglog < tests/BugLogHQ/install/mysql.sql
 before_script:
-- cfmatrix/bin/box cfconfig cfmapping list
 - chmod +x cfmatrix/run.sh
 script:
 - "./cfmatrix/run.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,13 @@ env:
     - CFENGINE=adobe@11
     - CFENGINE=adobe@2016
 before_install:
-- git clone https://github.com/foundeo/cfmatrix.git cfmatrix
+- git clone --depth 1 https://github.com/foundeo/cfmatrix.git cfmatrix
 - mysql -e 'CREATE DATABASE IF NOT EXISTS buglog;'
 install:
-- cfmatrix/bin/box install commandbox-cfconfig
-- cfmatrix/bin/box recipe recipeFile=cfmatrix/ci.boxr CFENGINE=$CFENGINE
+- bash ./cfmatrix/install.sh
 - mysql buglog < tests/BugLogHQ/install/mysql.sql
 before_script:
 - cfmatrix/bin/box cfconfig cfmapping list
-- chmod +x cfmatrix/run.sh
 script:
-- "./cfmatrix/run.sh"
+- bash ./cfmatrix/run.sh
 - cfmatrix/bin/box server log

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
 - cfmatrix/bin/box recipe recipeFile=cfmatrix/ci.boxr CFENGINE=$CFENGINE
 - mysql buglog < tests/BugLogHQ/install/mysql.sql
 before_script:
+- cfmatrix/bin/box cfconfig cfmapping list
 - chmod +x cfmatrix/run.sh
 script:
 - "./cfmatrix/run.sh"

--- a/box.json
+++ b/box.json
@@ -13,7 +13,7 @@
     },
     "devDependencies":{
         "testbox":"^2.5.0+107",
-        "commandbox-cfconfig":"be",
+        "commandbox-cfconfig":"^1.0.2",
         "di1":"git+https://github.com/framework-one/di1.git",
         "hoth":"git+https://github.com/aarongreenlee/Hoth.git",
         "BugLogHQ":"git+https://github.com/oarevalo/BugLogHQ.git"


### PR DESCRIPTION
There was an issue in commandbox that prevented the recipe from finishing when the box.json contains a command as a dependency (which this one does, cfconfig) causing the commandbox shell to reload, and it forgets to do the third step of the recipe (start the server). 

I switched to using `cfmatrix/install.sh` which can check to see if the server started and try to start it again.