### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 sudo: false
 jdk:
-- oraclejdk8
+- openjdk8
 services:
   - mysql
 env:


### PR DESCRIPTION
Use openjdk instead of oraclejdk because travis no longer supports it.