### PR TITLE
Add support for CSP Reporting & ndJSON

### DIFF
--- a/core/api.cfc
+++ b/core/api.cfc
@@ -695,6 +695,12 @@
 
 		<cfset requestObj.body = getRequestBody() />
 		<cfset requestObj.contentType = cgi.content_type />
+		<cfif requestObj.contentType is "application/csp-report">
+			<cfset requestObj.contentType = "application/json">
+		<cfelseif requestObj.contentType is "application/x-ndjson">
+			<cfset requestObj.contentType = "application/json">
+			<cfset requestObj.body = "[" & javacast("string", requestObj.body).replace("\n", ",") & "]">
+		</cfif>
 		<cfif len(requestObj.body) AND requestObj.body neq "null">
 			<cfif findNoCase("multipart/form-data", requestObj.contentType)>
 				<!--- do nothing, to support the way railo handles multipart requests (just avoids the error condition below) --->


### PR DESCRIPTION
CSP Reporting (`application/csp-report`) posts use standard JSON syntax, while ndJSON (`application/x-ndjson`) requires to be reformatted as an array of structs.