### PR TITLE
Add debug data to BugLogHQ exception logs

### DIFF
--- a/bonus/LogToBugLogHQ.cfc
+++ b/bonus/LogToBugLogHQ.cfc
@@ -41,6 +41,11 @@
 			<cfset msg = variables.message />
 		</cfif>
 
+		<!--- You can use addDebugData() in resources to set this value --->
+		<cfif structKeyExists(request, "debugData") and not structKeyExists(exception, "extraInfo")>
+			<cfset exception.extraInfo = request.debugData />
+		</cfif>
+
 		<cfset var reqHeaders = getHTTPRequestData().headers />
 		<cfset var reqBody = getHTTPRequestData().content />
 		<!--- on input with content-type "application/json" CF seems to expose it as binary data. Here we convert it back to plain text --->


### PR DESCRIPTION
Back in #327 we added `addDebugData()` and it adds contextual data for text and email logs. This extends that to also be included for BugLogHQ.﻿
