### PR TITLE
Replace colon with equals sign for older CF support

### DIFF
--- a/core/baseSerializer.cfc
+++ b/core/baseSerializer.cfc
@@ -107,7 +107,7 @@
 				noContent() returns with HTTP status code 204 and Content-Type as text/plain (omitting this header is difficult and maybe not recommanded)
 				noData() is kept 'as is' for backward compatibility with existing implementations
 		--->
-		<cfreturn this.withStatus(204).withHeaders({"Content-Type":"text/plain"}) />
+		<cfreturn this.withStatus(204).withHeaders({"Content-Type"="text/plain"}) />
 	</cffunction>
 
 	<cffunction name="setFileName" access="public" output="false" hint="Pass in a file-name (fully qualified, e.g. c:\temp\img.jpg) to have Taffy stream this file back to the client">


### PR DESCRIPTION
Replacing a colon with an equals sign in a struct definition to correct a bug that will only show up in CF versions less than 10. This is the root cause for issue #389.