### PR TITLE
Bug fix: "Query String Parameters" not appended to URL for POST/PUT/PATCH

### DIFF
--- a/dashboard/dash.js
+++ b/dashboard/dash.js
@@ -98,6 +98,10 @@ $(function(){
 			,path = uri.supplant(form);
 
 		var verb = resource.find('.reqMethod option:checked').val();
+		if (verb === 'POST' || verb === 'PUT' || verb === 'PATCH'){
+			path += '?' + qParams(resource);
+		}
+
 		var body = (verb === 'GET' || verb === 'DELETE') ? qParams(resource) : resource.find('.reqBody textarea').val();
 		var reqHeaders = resource.find('.requestHeaders').val().replace(/\r/g, '').split('\n');
 		var headers = {


### PR DESCRIPTION
Originally I found that I could not expand the Query Params box on version 3.1 if I had POST selected as the verb. That's been fixed by version 3.6. However I've found that the values set in "Query String Parameters" are not appended as query string parameters to the URL the request is made to when pressing the blue Send button.

I'm running Google Chrome 110.0.5481.105 on Windows. I think the versions make no difference as I don't see any code attempting to do this.

I've tested this change on version 3.6 with POST, PUT and PATCH verbs

