### PR TITLE
CF2025: Removing deprecated cfheader StatusText attribute

### DIFF
--- a/bonus/LogToScreen.cfc
+++ b/bonus/LogToScreen.cfc
@@ -9,7 +9,7 @@
 	<cffunction name="saveLog">
 		<cfargument name="exception" />
 		<cfcontent type="text/html" />
-		<cfheader statuscode="500" statustext="Unhandled API Error" />
+		<cfheader statuscode="500" />
 		<cfdump var="#arguments#" />
 		<cfif isDefined('request.debugData')>
 			<cfdump var="#request.debugData#" label="debug data" />

--- a/bonus/LogToScreen.cfc
+++ b/bonus/LogToScreen.cfc
@@ -9,7 +9,8 @@
 	<cffunction name="saveLog">
 		<cfargument name="exception" />
 		<cfcontent type="text/html" />
-		<cfheader statuscode="500" />
+		<cfinclude template="../core/cfHeaderHelper.cfm" />
+		<cfset setTaffyStatusHeader(500, "Unhandled API Error") />
 		<cfdump var="#arguments#" />
 		<cfif isDefined('request.debugData')>
 			<cfdump var="#request.debugData#" label="debug data" />

--- a/core/api.cfc
+++ b/core/api.cfc
@@ -146,7 +146,7 @@
 			<cfset logger.saveLog(exception) />
 
 			<!--- return 500 no matter what --->
-			<cfheader statuscode="500" statustext="Error" />
+			<cfheader statuscode="500" />
 			<cfcontent reset="true" />
 
 			<cfif structKeyExists(exception, "rootCause")>
@@ -177,7 +177,7 @@
 			</cfif>
 			<cfcatch>
 				<cfcontent reset="true" type="text/plain; charset=utf-8" />
-				<cfheader statuscode="500" statustext="Error" />
+				<cfheader statuscode="500" />
 				<cfoutput>An unhandled exception occurred: <cfif isStruct(root) and structKeyExists(root,"message")>#root.message#<cfelse>#root#</cfif> <cfif isStruct(root) and structKeyExists(root,"detail")>-- #root.detail#</cfif></cfoutput>
 				<cfdump var="#cfcatch#" format="text" label="ERROR WHEN LOGGING EXCEPTION" />
 				<cfdump var="#exception#" format="text" label="ORIGINAL EXCEPTION" />
@@ -422,7 +422,7 @@
 
 		<cfsetting enablecfoutputonly="true" />
 		<cfcontent reset="true" type="#getReturnMimeAsHeader(_taffyRequest.returnMimeExt)#; charset=utf-8" />
-		<cfheader statuscode="#_taffyRequest.statusArgs.statusCode#" statustext="#_taffyRequest.statusArgs.statusText#" />
+		<cfheader statuscode="#_taffyRequest.statusArgs.statusCode#" />
 
 		<!--- headers --->
 		<cfset addHeaders(_taffyRequest.resultHeaders) />
@@ -498,7 +498,7 @@
 						<cfset _taffyRequest.clientEtag = _taffyRequest.headers['If-None-Match'] />
 
 						<cfif len(_taffyRequest.clientEtag) gt 0 and _taffyRequest.clientEtag eq _taffyRequest.serverEtag>
-							<cfheader statuscode="304" statustext="Not Modified" />
+							<cfheader statuscode="304" />
 							<cfcontent reset="true" type="#application._taffy.settings.mimeExtensions[_taffyRequest.returnMimeExt]#; charset=utf-8" />
 							<cfreturn true />
 						<cfelse>
@@ -1117,7 +1117,7 @@
 		<cfargument name="headers" type="struct" required="false" default="#structNew()#" />
 		<cfcontent reset="true" />
 		<cfset addHeaders(arguments.headers) />
-		<cfheader statuscode="#arguments.statusCode#" statustext="#arguments.msg#" />
+		<cfheader statuscode="#arguments.statusCode#" />
 		<cfabort />
 	</cffunction>
 

--- a/core/api.cfc
+++ b/core/api.cfc
@@ -1,5 +1,23 @@
 <cfcomponent hint="Base class for taffy REST application's Application.cfc">
 
+	<!--- Instance-level utility for backwards compatible cfheader handling --->
+	<cfset variables.headerUtils = "" />
+
+	<!--- Lazy-loaded getter for header utility --->
+	<cffunction name="getHeaderUtils" access="private" output="false" returntype="any" hint="Returns header utility instance with lazy loading">
+		<cfif variables.headerUtils eq "">
+			<cfset variables.headerUtils = createObject("component", "taffy.core.cfHeaderUtils").init() />
+		</cfif>
+		<cfreturn variables.headerUtils />
+	</cffunction>
+
+	<!--- Wrapper function to maintain API compatibility --->
+	<cffunction name="setStatusHeader" access="private" output="false" returntype="void" hint="Sets HTTP status header with backwards compatibility">
+		<cfargument name="statusCode" type="numeric" required="true" hint="HTTP status code to set" />
+		<cfargument name="statusText" type="string" required="false" default="" hint="HTTP status text (optional for CF 2025+)" />
+		<cfset getHeaderUtils().setStatusHeader(arguments.statusCode, arguments.statusText) />
+	</cffunction>
+
 	<!--- this method is meant to be (optionally) overrided in your application.cfc --->
 	<cffunction name="getEnvironment" output="false" hint="override this function to define the current API environment"><cfreturn "" /></cffunction>
 
@@ -146,7 +164,7 @@
 			<cfset logger.saveLog(exception) />
 
 			<!--- return 500 no matter what --->
-			<cfheader statuscode="500" />
+			<cfset setStatusHeader(500, "Error") />
 			<cfcontent reset="true" />
 
 			<cfif structKeyExists(exception, "rootCause")>
@@ -177,7 +195,7 @@
 			</cfif>
 			<cfcatch>
 				<cfcontent reset="true" type="text/plain; charset=utf-8" />
-				<cfheader statuscode="500" />
+				<cfset setStatusHeader(500, "Error") />
 				<cfoutput>An unhandled exception occurred: <cfif isStruct(root) and structKeyExists(root,"message")>#root.message#<cfelse>#root#</cfif> <cfif isStruct(root) and structKeyExists(root,"detail")>-- #root.detail#</cfif></cfoutput>
 				<cfdump var="#cfcatch#" format="text" label="ERROR WHEN LOGGING EXCEPTION" />
 				<cfdump var="#exception#" format="text" label="ORIGINAL EXCEPTION" />
@@ -422,7 +440,7 @@
 
 		<cfsetting enablecfoutputonly="true" />
 		<cfcontent reset="true" type="#getReturnMimeAsHeader(_taffyRequest.returnMimeExt)#; charset=utf-8" />
-		<cfheader statuscode="#_taffyRequest.statusArgs.statusCode#" />
+		<cfset setStatusHeader(_taffyRequest.statusArgs.statusCode, _taffyRequest.statusArgs.statusText) />
 
 		<!--- headers --->
 		<cfset addHeaders(_taffyRequest.resultHeaders) />
@@ -498,7 +516,7 @@
 						<cfset _taffyRequest.clientEtag = _taffyRequest.headers['If-None-Match'] />
 
 						<cfif len(_taffyRequest.clientEtag) gt 0 and _taffyRequest.clientEtag eq _taffyRequest.serverEtag>
-							<cfheader statuscode="304" />
+							<cfset setStatusHeader(304, "Not Modified") />
 							<cfcontent reset="true" type="#application._taffy.settings.mimeExtensions[_taffyRequest.returnMimeExt]#; charset=utf-8" />
 							<cfreturn true />
 						<cfelse>
@@ -1117,7 +1135,7 @@
 		<cfargument name="headers" type="struct" required="false" default="#structNew()#" />
 		<cfcontent reset="true" />
 		<cfset addHeaders(arguments.headers) />
-		<cfheader statuscode="#arguments.statusCode#" />
+		<cfset setStatusHeader(arguments.statusCode, arguments.msg) />
 		<cfabort />
 	</cffunction>
 

--- a/core/baseDeserializer.cfc
+++ b/core/baseDeserializer.cfc
@@ -40,7 +40,7 @@
 		<cfargument name="headers" type="struct" required="false" default="#structNew()#" />
 		<cfcontent reset="true" />
 		<cfset addHeaders(arguments.headers) />
-		<cfheader statuscode="#arguments.statusCode#" statustext="#arguments.msg#" />
+		<cfheader statuscode="#arguments.statusCode#" />
 		<cfabort />
 	</cffunction>
 

--- a/core/baseDeserializer.cfc
+++ b/core/baseDeserializer.cfc
@@ -34,13 +34,24 @@
 	<!--- Helpers                      --->
 	<!--- ============================ --->
 
+	<!--- Instance-level utility for backwards compatible cfheader handling --->
+	<cfset variables.headerUtils = "" />
+
+	<!--- Lazy-loaded getter for header utility --->
+	<cffunction name="getHeaderUtils" access="private" output="false" returntype="any" hint="Returns header utility instance with lazy loading">
+		<cfif variables.headerUtils eq "">
+			<cfset variables.headerUtils = createObject("component", "taffy.core.cfHeaderUtils").init() />
+		</cfif>
+		<cfreturn variables.headerUtils />
+	</cffunction>
+
 	<cffunction name="throwError" access="private" output="false" returntype="void">
-		<cfargument name="statusCode" type="numeric" default="500" />
+		<cfargument name="statusCode" type="numeric" default="500" hint="HTTP status code to return" />
 		<cfargument name="msg" type="string" required="true" hint="message to return to api consumer" />
-		<cfargument name="headers" type="struct" required="false" default="#structNew()#" />
+		<cfargument name="headers" type="struct" required="false" default="#structNew()#" hint="additional HTTP headers" />
 		<cfcontent reset="true" />
 		<cfset addHeaders(arguments.headers) />
-		<cfheader statuscode="#arguments.statusCode#" />
+		<cfset getHeaderUtils().setStatusHeader(arguments.statusCode, arguments.msg) />
 		<cfabort />
 	</cffunction>
 

--- a/core/cfHeaderHelper.cfm
+++ b/core/cfHeaderHelper.cfm
@@ -1,0 +1,21 @@
+<!---
+	Global utility function wrapper for backwards compatible cfheader handling.
+	
+	This provides a simple function interface that wraps the cfHeaderUtils.cfc component.
+	The CFC is cached in application scope for performance. This helper allows code to call
+	setTaffyStatusHeader() directly without managing component instances.
+--->
+
+<cffunction name="setTaffyStatusHeader" output="false" returntype="void" hint="Sets HTTP status header with backwards compatibility for CF 2025">
+	<cfargument name="statusCode" type="numeric" required="true" hint="HTTP status code to set" />
+	<cfargument name="statusText" type="string" required="false" default="" hint="HTTP status text (optional for CF 2025+)" />
+	
+	<cfscript>
+		// Use application scope to cache the utility instance
+		if (!structKeyExists(application, "_taffyHeaderUtils")) {
+			application._taffyHeaderUtils = createObject("component", "taffy.core.cfHeaderUtils").init();
+		}
+		
+		application._taffyHeaderUtils.setStatusHeader(arguments.statusCode, arguments.statusText);
+	</cfscript>
+</cffunction>

--- a/core/cfHeaderUtils.cfc
+++ b/core/cfHeaderUtils.cfc
@@ -1,0 +1,63 @@
+<!---
+	Core component class for backwards compatible HTTP status header handling for ColdFusion 2025+
+	where the statustext attribute has been deprecated.
+	
+	This CFC provides the structured, testable implementation with dependency injection support.
+	For a simple global function interface, see cfHeaderHelper.cfm which wraps this component.
+--->
+<cfcomponent hint="Utility component for backwards compatible cfheader handling">
+
+	<!--- Cache the CF version check since it won't change during execution --->
+	<cfset variables.isCF2025OrLater = "" />
+	<cfset variables.serverInfo = "" />
+
+	<!--- Constructor to inject server information --->
+	<cffunction name="init" access="public" output="false" returntype="any" hint="Constructor with optional server info injection">
+		<cfargument name="serverInfo" type="struct" required="false" default="#structNew()#" hint="Server info for testing/injection" />
+		
+		<cfscript>
+			if (structIsEmpty(arguments.serverInfo)) {
+				// Only reference server scope if no injection provided
+				variables.serverInfo = server;
+			} else {
+				variables.serverInfo = arguments.serverInfo;
+			}
+		</cfscript>
+		
+		<cfreturn this />
+	</cffunction>
+
+	<cffunction name="setStatusHeader" access="public" output="false" returntype="void" hint="Sets HTTP status header with backwards compatibility for CF 2025">
+		<cfargument name="statusCode" type="numeric" required="true" hint="HTTP status code to set" />
+		<cfargument name="statusText" type="string" required="false" default="" hint="HTTP status text (optional for CF 2025+)" />
+		
+		<cfscript>
+			if (isColdFusion2025OrLater()) {
+				cfheader(statuscode=arguments.statusCode);
+			} else {
+				if (len(arguments.statusText)) {
+					cfheader(statuscode=arguments.statusCode, statustext=arguments.statusText);
+				} else {
+					cfheader(statuscode=arguments.statusCode);
+				}
+			}
+		</cfscript>
+	</cffunction>
+
+	<cffunction name="isColdFusion2025OrLater" access="public" output="false" returntype="boolean" hint="Detects if running ColdFusion 2025 or later">
+		<cfscript>
+			// Cache the result since CF version won't change during execution
+			if (variables.isCF2025OrLater == "") {
+				var cfVersion = 0;
+				if (structKeyExists(variables.serverInfo, "coldfusion") && 
+					structKeyExists(variables.serverInfo.coldfusion, "productname") &&
+					variables.serverInfo.coldfusion.productname contains "ColdFusion") {
+					cfVersion = val(listFirst(variables.serverInfo.coldfusion.productversion));
+				}
+				variables.isCF2025OrLater = (cfVersion >= 2025);
+			}
+			return variables.isCF2025OrLater;
+		</cfscript>
+	</cffunction>
+
+</cfcomponent>

--- a/core/cfHeaderUtils.cfc
+++ b/core/cfHeaderUtils.cfc
@@ -52,7 +52,13 @@
 				if (structKeyExists(variables.serverInfo, "coldfusion") && 
 					structKeyExists(variables.serverInfo.coldfusion, "productname") &&
 					variables.serverInfo.coldfusion.productname contains "ColdFusion") {
-					cfVersion = val(listFirst(variables.serverInfo.coldfusion.productversion));
+					// Extract the first number from the productversion string, regardless of format
+					var versionMatch = reMatch("\d+", variables.serverInfo.coldfusion.productversion);
+					if (arrayLen(versionMatch) > 0) {
+						cfVersion = val(versionMatch[1]);
+					} else {
+						cfVersion = 0;
+					}
 				}
 				variables.isCF2025OrLater = (cfVersion >= 2025);
 			}

--- a/dashboard/asset.cfm
+++ b/dashboard/asset.cfm
@@ -28,7 +28,7 @@
 	</cfcase>
 
 	<cfdefaultcase>
-		<cfheader statuscode="404" statustext="Not Found" />
+		<cfheader statuscode="404" />
 		<cfcontent reset="true" /><cfabort />
 	</cfdefaultcase>
 

--- a/dashboard/asset.cfm
+++ b/dashboard/asset.cfm
@@ -28,7 +28,8 @@
 	</cfcase>
 
 	<cfdefaultcase>
-		<cfheader statuscode="404" />
+		<cfinclude template="../core/cfHeaderHelper.cfm" />
+		<cfset setTaffyStatusHeader(404, "Not Found") />
 		<cfcontent reset="true" /><cfabort />
 	</cfdefaultcase>
 

--- a/tests/tests/TestCfHeaderUtils.cfc
+++ b/tests/tests/TestCfHeaderUtils.cfc
@@ -1,0 +1,192 @@
+component extends="base" {
+
+	function beforeTests() {
+		variables.headerUtils = "";
+	}
+
+	function setup() {
+		// Create fresh instance for each test
+		variables.headerUtils = createObject("component", "taffy.core.cfHeaderUtils");
+	}
+
+	// Test constructor with no server info (will use actual server scope)
+	function test_init_with_no_server_info() {
+		var result = variables.headerUtils.init();
+		assertEquals(variables.headerUtils, result, "init() should return this");
+	}
+
+	// Test constructor with mock server info for CF 2024
+	function test_init_with_cf2024_server_info() {
+		var mockServerInfo = {
+			coldfusion: {
+				productname: "ColdFusion",
+				productversion: "2024.0.0"
+			}
+		};
+		
+		var result = variables.headerUtils.init(mockServerInfo);
+		assertEquals(variables.headerUtils, result, "init() should return this");
+		assertEquals(false, result.isColdFusion2025OrLater(), "CF 2024 should not be detected as 2025+");
+	}
+
+	// Test constructor with mock server info for CF 2025
+	function test_init_with_cf2025_server_info() {
+		var mockServerInfo = {
+			coldfusion: {
+				productname: "ColdFusion",
+				productversion: "2025.0.0"
+			}
+		};
+		
+		var result = variables.headerUtils.init(mockServerInfo);
+		assertEquals(variables.headerUtils, result, "init() should return this");
+		assertEquals(true, result.isColdFusion2025OrLater(), "CF 2025 should be detected as 2025+");
+	}
+
+	// Test constructor with mock server info for CF 2026
+	function test_init_with_cf2026_server_info() {
+		var mockServerInfo = {
+			coldfusion: {
+				productname: "ColdFusion",
+				productversion: "2026.0.0"
+			}
+		};
+		
+		var result = variables.headerUtils.init(mockServerInfo);
+		assertEquals(true, result.isColdFusion2025OrLater(), "CF 2026 should be detected as 2025+");
+	}
+
+	// Test with Lucee server info (should not be detected as CF 2025+)
+	function test_init_with_lucee_server_info() {
+		var mockServerInfo = {
+			lucee: {
+				version: "5.3.8.206"
+			},
+			coldfusion: {
+				productname: "Lucee",
+				productversion: "5.3.8"
+			}
+		};
+		
+		var result = variables.headerUtils.init(mockServerInfo);
+		assertEquals(false, result.isColdFusion2025OrLater(), "Lucee should not be detected as CF 2025+");
+	}
+
+	// Test with non-ColdFusion server info
+	function test_init_with_non_cf_server_info() {
+		var mockServerInfo = {
+			os: {
+				name: "Windows"
+			}
+		};
+		
+		var result = variables.headerUtils.init(mockServerInfo);
+		assertEquals(false, result.isColdFusion2025OrLater(), "Non-CF server should not be detected as CF 2025+");
+	}
+
+	// Test version detection caching
+	function test_version_detection_caching() {
+		var mockServerInfo = {
+			coldfusion: {
+				productname: "ColdFusion",
+				productversion: "2025.0.0"
+			}
+		};
+		
+		var util = variables.headerUtils.init(mockServerInfo);
+		
+		// First call
+		var result1 = util.isColdFusion2025OrLater();
+		// Second call should use cached result
+		var result2 = util.isColdFusion2025OrLater();
+		
+		assertEquals(result1, result2, "Cached version detection should return same result");
+		assertEquals(true, result1, "CF 2025 should be detected correctly");
+	}
+
+	// Test setStatusHeader method (we can't easily test the actual cfheader call, 
+	// but we can test that the method executes without error)
+	function test_setStatusHeader_with_cf2024() {
+		var mockServerInfo = {
+			coldfusion: {
+				productname: "ColdFusion",
+				productversion: "2024.0.0"
+			}
+		};
+		
+		var util = variables.headerUtils.init(mockServerInfo);
+		
+		// This should execute without throwing an exception
+		// Note: We can't easily test the actual cfheader output in unit tests
+		try {
+			util.setStatusHeader(500, "Test Error");
+			// If we get here, the method executed without error
+			assertTrue(true, "setStatusHeader should execute without error for CF 2024");
+		} catch (any e) {
+			fail("setStatusHeader should not throw exception: " & e.message);
+		}
+	}
+
+	function test_setStatusHeader_with_cf2025() {
+		var mockServerInfo = {
+			coldfusion: {
+				productname: "ColdFusion",
+				productversion: "2025.0.0"
+			}
+		};
+		
+		var util = variables.headerUtils.init(mockServerInfo);
+		
+		try {
+			util.setStatusHeader(404, "Not Found");
+			assertTrue(true, "setStatusHeader should execute without error for CF 2025");
+		} catch (any e) {
+			fail("setStatusHeader should not throw exception: " & e.message);
+		}
+	}
+
+	function test_setStatusHeader_without_statustext() {
+		var mockServerInfo = {
+			coldfusion: {
+				productname: "ColdFusion",
+				productversion: "2024.0.0"
+			}
+		};
+		
+		var util = variables.headerUtils.init(mockServerInfo);
+		
+		try {
+			util.setStatusHeader(200);
+			assertTrue(true, "setStatusHeader should work without statusText parameter");
+		} catch (any e) {
+			fail("setStatusHeader should not throw exception when statusText is empty: " & e.message);
+		}
+	}
+
+	// Test edge case version strings
+	function test_version_detection_with_complex_version() {
+		var mockServerInfo = {
+			coldfusion: {
+				productname: "ColdFusion",
+				productversion: "2025.1.2.3-UPDATE1"
+			}
+		};
+		
+		var util = variables.headerUtils.init(mockServerInfo);
+		assertEquals(true, util.isColdFusion2025OrLater(), "Should handle complex version strings");
+	}
+
+	function test_version_detection_with_cf11() {
+		var mockServerInfo = {
+			coldfusion: {
+				productname: "ColdFusion",
+				productversion: "11.0.0"
+			}
+		};
+		
+		var util = variables.headerUtils.init(mockServerInfo);
+		assertEquals(false, util.isColdFusion2025OrLater(), "CF 11 should not be detected as 2025+");
+	}
+
+
+}

--- a/tests/tests/TestCfHeaderUtils.cfc
+++ b/tests/tests/TestCfHeaderUtils.cfc
@@ -176,6 +176,71 @@ component extends="base" {
 		assertEquals(true, util.isColdFusion2025OrLater(), "Should handle complex version strings");
 	}
 
+	// Test version string with text prefix
+	function test_version_detection_with_text_prefix() {
+		var mockServerInfo = {
+			coldfusion: {
+				productname: "ColdFusion",
+				productversion: "ColdFusion 2025"
+			}
+		};
+		
+		var util = variables.headerUtils.init(mockServerInfo);
+		assertEquals(true, util.isColdFusion2025OrLater(), "Should extract version from 'ColdFusion 2025' format");
+	}
+
+	// Test empty version string
+	function test_version_detection_with_empty_version() {
+		var mockServerInfo = {
+			coldfusion: {
+				productname: "ColdFusion",
+				productversion: ""
+			}
+		};
+		
+		var util = variables.headerUtils.init(mockServerInfo);
+		assertEquals(false, util.isColdFusion2025OrLater(), "Empty version should return false");
+	}
+
+	// Test non-numeric version string
+	function test_version_detection_with_non_numeric_version() {
+		var mockServerInfo = {
+			coldfusion: {
+				productname: "ColdFusion",
+				productversion: "Latest"
+			}
+		};
+		
+		var util = variables.headerUtils.init(mockServerInfo);
+		assertEquals(false, util.isColdFusion2025OrLater(), "Non-numeric version should return false");
+	}
+
+	// Test version with build prefix
+	function test_version_detection_with_build_prefix() {
+		var mockServerInfo = {
+			coldfusion: {
+				productname: "ColdFusion",
+				productversion: "Build 2025.0.0.12345"
+			}
+		};
+		
+		var util = variables.headerUtils.init(mockServerInfo);
+		assertEquals(true, util.isColdFusion2025OrLater(), "Should extract version from 'Build 2025...' format");
+	}
+
+	// Test malformed version data
+	function test_version_detection_with_malformed_data() {
+		var mockServerInfo = {
+			coldfusion: {
+				productname: "ColdFusion",
+				productversion: "!@#$%"
+			}
+		};
+		
+		var util = variables.headerUtils.init(mockServerInfo);
+		assertEquals(false, util.isColdFusion2025OrLater(), "Malformed version should return false");
+	}
+
 	function test_version_detection_with_cf11() {
 		var mockServerInfo = {
 			coldfusion: {

--- a/tests/tests/TestHeaderCompatibility.cfc
+++ b/tests/tests/TestHeaderCompatibility.cfc
@@ -1,0 +1,95 @@
+component extends="base" {
+
+	function beforeTests() {
+		// These tests will verify our changes work in real scenarios
+	}
+
+	// Test that the global helper function works
+	function test_global_helper_function() {
+		try {
+			// Include the helper and test it doesn't throw errors
+			include "../../core/cfHeaderHelper.cfm";
+			
+			// Create a simple test that exercises the function
+			// Note: We can't easily capture HTTP headers in unit tests,
+			// but we can verify the function executes without error
+			setTaffyStatusHeader(200, "OK");
+			
+			assertTrue(true, "Global helper function should execute without error");
+		} catch (any e) {
+			fail("Global helper function failed: " & e.message);
+		}
+	}
+
+	// Test API component integration
+	function test_api_component_integration() {
+		try {
+			// Create an instance of the API component
+			var apiComponent = createObject("component", "taffy.core.api");
+			
+			// Test that it has the setStatusHeader method
+			assertTrue(structKeyExists(apiComponent, "setStatusHeader"), "API component should have setStatusHeader method");
+			
+			// Test calling the method (this will use private access, so we'll test indirectly)
+			assertTrue(true, "API component loads successfully");
+		} catch (any e) {
+			fail("API component integration failed: " & e.message);
+		}
+	}
+
+	// Test baseDeserializer component integration
+	function test_baseDeserializer_integration() {
+		try {
+			var deserializer = createObject("component", "taffy.core.baseDeserializer");
+			
+			assertTrue(true, "Base deserializer loads successfully with header utils");
+		} catch (any e) {
+			fail("Base deserializer integration failed: " & e.message);
+		}
+	}
+
+	// Test LogToScreen bonus component
+	function test_logToScreen_integration() {
+		try {
+			var logger = createObject("component", "taffy.bonus.LogToScreen");
+			var result = logger.init({});
+			
+			assertTrue(true, "LogToScreen component loads successfully");
+		} catch (any e) {
+			fail("LogToScreen integration failed: " & e.message);
+		}
+	}
+
+	// Test version detection with actual server scope
+	function test_actual_server_version_detection() {
+		try {
+			var headerUtils = createObject("component", "taffy.core.cfHeaderUtils").init();
+			var isModern = headerUtils.isColdFusion2025OrLater();
+			
+			// This should work regardless of the actual CF version
+			assertTrue(isBoolean(isModern), "Version detection should return boolean");
+			
+			// Log the actual detection for debugging
+			debug("Detected CF 2025+: " & isModern);
+			debug("Server product name: " & server.coldfusion.productname);
+			debug("Server version: " & server.coldfusion.productversion);
+			
+		} catch (any e) {
+			fail("Actual server version detection failed: " & e.message);
+		}
+	}
+
+	// Test that our changes don't break existing functionality
+	function test_backwards_compatibility() {
+		try {
+			// Test that we can still create objects the old way
+			var headerUtils = createObject("component", "taffy.core.cfHeaderUtils");
+			var initialized = headerUtils.init();
+			
+			assertTrue(true, "Backwards compatibility maintained");
+		} catch (any e) {
+			fail("Backwards compatibility test failed: " & e.message);
+		}
+	}
+
+}

--- a/tests/tests/run.cfm
+++ b/tests/tests/run.cfm
@@ -36,7 +36,7 @@
 <cfset resultObject = r.getResult()>
 <cfset errors       = resultObject.getTotalFail() + resultObject.getTotalError()>
 <cfif errors GT 0>
-	<cfheader statuscode="500" statustext="Tests Failed">
+	<cfheader statuscode="500">
 </cfif>
 
 <cfif NOT plainText>

--- a/tests/tests/run.cfm
+++ b/tests/tests/run.cfm
@@ -36,7 +36,8 @@
 <cfset resultObject = r.getResult()>
 <cfset errors       = resultObject.getTotalFail() + resultObject.getTotalError()>
 <cfif errors GT 0>
-	<cfheader statuscode="500">
+	<cfinclude template="../../core/cfHeaderHelper.cfm" />
+	<cfset setTaffyStatusHeader(500, "Tests Failed") />
 </cfif>
 
 <cfif NOT plainText>


### PR DESCRIPTION
* Attribute is no longer available in ColdFusion 2025. Using it causes an "Attribute validation error for CFHEADER tag".

Let me know if you wanted to have some backwards compatibility code to still retain StatusText for older versions of ColdFusion.