### PR TITLE
Added new exposeTaffyHeaders

### DIFF
--- a/box.json
+++ b/box.json
@@ -3,7 +3,7 @@
     "shortDescription":"REST Web Service framework for ColdFusion and Lucee",
     "slug":"taffy",
     "author":"Adam Tuttle",
-    "version":"3.7.0",
+    "version":"3.8.0",
     "homepage":"https://taffy.io/",
     "documentation":"https://docs.taffy.io/",
     "type":"mvc",

--- a/docs/@next.md
+++ b/docs/@next.md
@@ -396,6 +396,7 @@ variables.framework = {
 
 	unhandledPaths = "/flex2gateway",
 	allowCrossDomain = false,
+	exposeTaffyHeaders = true,
 	globalHeaders = structNew(),
 	debugKey = "debug",
 
@@ -574,6 +575,27 @@ In addition, as of Taffy 3.1.0, you can set this setting to a string of allowabl
 variables.framework.allowCrossDomain =
   "http://example.com; http://foo.bar, http://google.com";
 ```
+
+#### exposeTaffyHeaders
+
+**Available in:** Taffy 3.8+<br/>
+**Type:** Boolean<br/>
+**Default:** true<br/>
+**Description:** Determines if the standard Taffy debug HTTP response headers should be included with each request. The Taffy debug headers are:
+
+* `X-TAFFY-RELOADED` — Determines if the Taffy configuration was reloaded on the request.
+* `X-TIME-TO-RELOAD` — The time it took for Taffy to initialize.
+* `X-TIME-IN-PARSE` — The time it took to parse the response.
+* `X-TIME-IN-ONTAFFYREQUEST` — The time spent in the `onTaffyRequest` method.
+* `X-TIME-IN-RESOURCE` — The time spent executing the requested resource.
+* `X-TIME-IN-CACHE-CHECK` — The time spent checking for a cached response. 
+* `X-TIME-IN-CACHE-GET` — The time spent to retrieve a cached response.
+* `X-TIME-IN-CACHE-SAVE` — The time spent to save a cached response.
+* `X-TIME-IN-SERIALIZE` — The time spent serializing the response.
+* `X-TIME-IN-TAFFY` — The time spent executing the Taffy internals.
+* `X-TIME-IN-ONTAFFYREQUESTEND` — The time spent in the `onTaffyRequestEnd` method.
+
+Setting this to `false` will prevent these response headers from being written to the HTTP stream.
 
 #### globalHeaders
 

--- a/docs/@next.md
+++ b/docs/@next.md
@@ -585,7 +585,7 @@ variables.framework.allowCrossDomain =
 
 * `X-TAFFY-RELOADED` — Determines if the Taffy configuration was reloaded on the request.
 * `X-TIME-TO-RELOAD` — The time it took for Taffy to initialize.
-* `X-TIME-IN-PARSE` — The time it took to parse the response.
+* `X-TIME-IN-PARSE` — The time it took to parse the request.
 * `X-TIME-IN-ONTAFFYREQUEST` — The time spent in the `onTaffyRequest` method.
 * `X-TIME-IN-RESOURCE` — The time spent executing the requested resource.
 * `X-TIME-IN-CACHE-CHECK` — The time spent checking for a cached response. 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cfml-taffy",
-	"version": "3.7.0",
+	"version": "3.8.0",
 	"author": "Adam Tuttle <adamtuttlecodes@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://taffy.io",

--- a/tests/Application.cfc
+++ b/tests/Application.cfc
@@ -29,6 +29,7 @@
 		variables.framework.globalHeaders = {};
 		variables.framework.globalHeaders["x-foo-globalheader"] = "snafu";
 		variables.framework.exposeHeaders = true;
+		variables.framework.exposeTaffyHeaders = true;
 
 		variables.framework.environments = {};
 		variables.framework.environments.test = {};


### PR DESCRIPTION
This PR add support for a new `exposeTaffyHeaders` setting, which is `true` by default to preserve backwards compatibility.

When set to `false`, it will prevent the following headers from being sent in the HTTP response:

* `X-TAFFY-RELOADED` 
* `X-TIME-TO-RELOAD`
* `X-TIME-IN-PARSE`
* `X-TIME-IN-ONTAFFYREQUEST`
* `X-TIME-IN-RESOURCE`
* `X-TIME-IN-CACHE-CHECK` 
* `X-TIME-IN-CACHE-GET`
* `X-TIME-IN-CACHE-SAVE`
* `X-TIME-IN-SERIALIZE`
* `X-TIME-IN-TAFFY`
* `X-TIME-IN-ONTAFFYREQUESTEND`

I also updated the documentation to document what each of these headers means (at least based on my understanding).

My intention was to include unit tests for this, but I was running into tons of issues trying to get the unit tests running in Commandbox. The documentation here seems be very outdated.
