### PR TITLE
Add support for new resourcesCFCPath setting

### DIFF
--- a/box.json
+++ b/box.json
@@ -3,7 +3,7 @@
     "shortDescription":"REST Web Service framework for ColdFusion and Lucee",
     "slug":"taffy",
     "author":"Adam Tuttle",
-    "version":"3.7.0",
+    "version":"3.8.0",
     "homepage":"https://taffy.io/",
     "documentation":"https://docs.taffy.io/",
     "type":"mvc",

--- a/core/api.cfc
+++ b/core/api.cfc
@@ -614,6 +614,7 @@
 		<cfset local._taffy.endpoints = structNew() />
 		<!--- default settings --->
 		<cfset local.defaultConfig = structNew() />
+		<cfset local.defaultConfig.resourcesCFCPath = "" />
 		<cfset local.defaultConfig.docs = structNew() />
 		<cfset local.defaultConfig.docs.APIName = "Your API Name (variables.framework.docs.APIName)" />
 		<cfset local.defaultConfig.docs.APIVersion = "0.0.0 (variables.framework.docs.APIVersion)" />
@@ -679,7 +680,7 @@
 			',', '|', 'all' )
 		/>
 		<!--- if resources folder exists, use internal bean factory --->
-		<cfset local.resourcePath = guessResourcesFullPath() />
+		<cfset local.resourcePath = guessResourcesFullPath(local._taffy.settings.resourcesCFCPath) />
 		<cfset local.noResources = false />
 		<cfif directoryExists(local.resourcePath)>
 			<!--- setup internal bean factory --->
@@ -689,7 +690,7 @@
 			<cfelse>
 				<cfset local._taffy.factory.init() />
 			</cfif>
-			<cfset local._taffy.factory.loadBeansFromPath(local.resourcePath, guessResourcesCFCPath(), guessResourcesFullPath(), true, local._taffy) />
+			<cfset local._taffy.factory.loadBeansFromPath(local.resourcePath, guessResourcesCFCPath(local._taffy.settings.resourcesCFCPath), local.resourcePath, true, local._taffy) />
 			<cfset local._taffy.beanList = local._taffy.factory.getBeanList() />
 			<cfset local._taffy.endpoints = cacheBeanMetaData(local._taffy.factory, local._taffy.beanList, local._taffy) />
 			<cfset local._taffy.status.internalBeanFactoryUsed = true />
@@ -1102,10 +1103,24 @@
 	</cffunction>
 
 	<cffunction name="guessResourcesFullPath" access="private" output="false" returntype="string">
+		<cfargument name="dottedPath" type="string" required="false" default="" hint="dotted path to a resource folder to use" />
+
+		<!--- when we have an explicit path, no need to make a guess, we just need to convert the dotted path to a file path --->
+		<cfif len(arguments.dottedPath)>
+			<cfreturn expandPath("/" & replace(arguments.dottedPath, ".", "/", "all")) />
+		</cfif>
+
 		<cfreturn expandPath(guessResourcesPath()) />
 	</cffunction>
 
 	<cffunction name="guessResourcesCFCPath" access="private" output="false" returntype="string">
+		<cfargument name="dottedPath" type="string" required="false" default="" hint="dotted path to a resource folder to use" />
+
+		<!--- when we have an explicit path, no need to make a guess --->
+		<cfif len(arguments.dottedPath)>
+			<cfreturn arguments.dottedPath />
+		</cfif>
+
 		<cfset var path = guessResourcesPath() />
 		<cfif left(path, 1) eq "/"><cfset path = right(path, len(path)-1) /></cfif>
 		<cfreturn reReplace(path, "\/", ".", "all") />

--- a/docs/@next.md
+++ b/docs/@next.md
@@ -75,11 +75,15 @@ Using sub-folders requires the use of Application-Specific Mappings (introduced 
 
 You can see that the taffy folder is a sibling to Application.cfc. This allows Application.cfc to use relative paths to extend `taffy.core.api`.
 
-Next, if your Application.cfc and `/resources/` folder aren't in the web-root (e.g. they're inside something like `/api/`) then you'll need to add an [application-specific mapping](http://livedocs.adobe.com/coldfusion/8/htmldocs/help.html?content=appFramework_04.html) for `/resources` so that Taffy can find your resources to initialize the routes.
+Next, if your Application.cfc and `/resources/` folder aren't in the web-root (e.g. they're inside something like `/api/`) then you'll need to do one of the following:
 
-```js
-this.mappings["/resources"] = expandPath("./resources");
-```
+* Add an [application-specific mapping](http://livedocs.adobe.com/coldfusion/8/htmldocs/help.html?content=appFramework_04.html) for `/resources` so that Taffy can find your resources to initialize the routes.
+
+	```js
+	this.mappings["/resources"] = expandPath("../api/resources");
+	```
+* You can specify the path to your resource components using the [`resourcesCFCPath`](#resourcescfcpath) setting to specify the dotted path to your resource folder. This will allow you to store your resource components in the directory of your choosing.
+
 
 You'll also need to add a mapping for `/taffy` so that the resources can extend `taffy.core.resource` (since the taffy folder isn't a child of the resources folder):
 
@@ -366,6 +370,7 @@ Default values:
 
 ```js
 variables.framework = {
+	resourcesCFCPath = "", 
 	reloadKey = "reload",
 	reloadPassword = "true",
 	reloadOnEveryRequest = false,
@@ -410,6 +415,13 @@ variables.framework = {
 	environments = {}
 };
 ```
+
+#### resourcesCFCPath
+
+**Available in:** Taffy 3.8+<br/>
+**Type:** String<br/>
+**Default:** ""<br/>
+**Description:** By default, Taffy will attempt to load your resource components from either a child folder named `resources` or from a CF mapping named `resources`. You can use this setting to define an explicit path to your resource components using the "dotted" path of your resource folder (e.g. `myapp.api.rest-cfcs`). 
 
 #### reloadKey
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cfml-taffy",
-	"version": "3.7.0",
+	"version": "3.8.0",
 	"author": "Adam Tuttle <adamtuttlecodes@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://taffy.io",

--- a/tests/Application.cfc
+++ b/tests/Application.cfc
@@ -8,6 +8,8 @@
 		this.mappings["/bugLog"] = this.dirPath & "BugLogHQ/";
 		this.mappings["/Hoth"] = this.dirPath & "Hoth/";
 		this.mappings["/di1"] = this.dirPath & "di1/";
+		// an alternative mapping to our sources folder
+		this.mappings["/api/components"] = this.dirPath & "resources/";
 
 		this.system = createObject("java", "java.lang.System");
 		this.datasources["bugLog"] = {
@@ -21,6 +23,10 @@
 
 
 		variables.framework = {};
+		// // this would load from our alternative mapping
+		// variables.framework.resourcesCFCPath = "api.components";
+		// // this is a path that does not exist, so would not return resources
+		// variables.framework.resourcesCFCPath = "api.invalid";
 		variables.framework.disableDashboard = false;
 		variables.framework.reloadKey = "reload";
 		variables.framework.unhandledPaths = "/Taffy/tests/someFolder,/Taffy/tests/tests,/tests/someFolder,/tests/tests,BugLogHQ";


### PR DESCRIPTION
Added new resourcesCFCPath setting which allows you to configure the "resources" components path in cases where the "resource" folder may conflict with existing directory structures. The default behavior is unchanged (for backwards compatibility), you would only need to set this when the `/resources` folder conflicts with your existing application or you just want to use your own directory structure.

For example, instead of using the `resources` convention you could place your resources in a completely different directory using:

```
variables.framework.resourcesCFCPath = "private.api.components"
```

This would expect all your Taffy "resources" would live in the physical folder of `expandPath('/private/api/components')` and that your components can be creating using the dotted path prefix of `private.api.components`.
